### PR TITLE
Promote tested Pi Chronos baseline to main

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,16 +11,33 @@ Run:
 """
 
 from contextlib import asynccontextmanager
+import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.database import init_db
 
 
+logger = logging.getLogger(__name__)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup/shutdown lifecycle."""
     init_db()
+    try:
+        from src.plaud_oauth import PlaudOAuthClient
+
+        status = PlaudOAuthClient().token_status_with_recovery(attempt_recovery=True)
+        if status.get("is_authenticated"):
+            logger.info("Plaud auth is ready")
+        else:
+            logger.warning(
+                "Plaud auth not connected on startup (has_refresh_token=%s)",
+                status.get("has_refresh_token"),
+            )
+    except Exception as exc:  # pragma: no cover - startup should stay resilient
+        logger.warning("Plaud auth warmup failed: %s", exc)
     yield
 
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -25,7 +25,7 @@ async def plaud_status():
     from src.plaud_oauth import PlaudOAuthClient
 
     client = PlaudOAuthClient()
-    ts = client.token_status_with_recovery(attempt_recovery=True)
+    ts = client.token_status
     return TokenStatusOut(
         is_authenticated=ts.get("is_authenticated", False),
         has_access_token=ts.get("has_access_token", False),

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -4,13 +4,15 @@ import os
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 
 from api.schemas.responses import AuthURLResponse, TokenExchangeRequest, TokenStatusOut
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
 # In-memory map: OAuth state → metadata about the flow source/return path.
+_plaud_oauth_pending: dict[str, dict[str, str]] = {}
+_plaud_oauth_completed: dict[str, dict[str, str]] = {}
 _notion_oauth_pending: dict[str, dict[str, str]] = {}
 
 
@@ -23,7 +25,7 @@ async def plaud_status():
     from src.plaud_oauth import PlaudOAuthClient
 
     client = PlaudOAuthClient()
-    ts = client.token_status
+    ts = client.token_status_with_recovery(attempt_recovery=True)
     return TokenStatusOut(
         is_authenticated=ts.get("is_authenticated", False),
         has_access_token=ts.get("has_access_token", False),
@@ -37,13 +39,102 @@ async def plaud_status():
 
 
 @router.get("/plaud/authorize", response_model=AuthURLResponse)
-async def plaud_authorize():
-    """Get Plaud OAuth authorization URL."""
+async def plaud_authorize(request: Request):
+    """Get Plaud OAuth authorization URL.
+
+    Pass ``?mobile=true`` from iOS so the callback redirects back into the app
+    after the server exchanges the code. Web callers can omit it and optionally
+    provide ``return_to`` to land back on the browser UI.
+    """
     from src.plaud_oauth import PlaudOAuthClient
 
-    client = PlaudOAuthClient()
+    mobile = request.query_params.get("mobile", "").lower() in ("true", "1")
+    return_to = _clean_return_to(request.query_params.get("return_to", ""))
+    redirect_uri = _plaud_redirect_uri(request)
+    client = PlaudOAuthClient(redirect_uri=redirect_uri)
     url, state = client.get_authorization_url()
+    _plaud_oauth_pending[state] = {
+        "source": "mobile" if mobile else "web",
+        "return_to": return_to,
+    }
     return AuthURLResponse(auth_url=url, state=state)
+
+
+@router.options("/plaud/callback")
+async def plaud_callback_options():
+    """Plaud may preflight the callback URL before sending the real GET."""
+    return Response(status_code=204)
+
+
+@router.get("/plaud/callback")
+async def plaud_callback(
+    request: Request, code: str = "", state: str = "", error: str = ""
+):
+    """Handle Plaud OAuth redirect and bounce back to mobile or web.
+
+    Plaud may hit this route more than once for the same state.  We keep a small
+    in-memory completion map so duplicate GETs redirect consistently instead of
+    failing after the first successful exchange.
+    """
+    pending = _plaud_oauth_pending.get(state, {})
+    completed = _plaud_oauth_completed.get(state)
+    source = pending.get("source") or (completed or {}).get("source", "mobile")
+    return_to = pending.get("return_to") or (completed or {}).get("return_to", "")
+
+    if completed:
+        if completed.get("status") == "success":
+            return _plaud_redirect(source, return_to=return_to, success=True)
+        return _plaud_redirect(
+            source,
+            return_to=return_to,
+            error=completed.get("error", "authorization_failed"),
+        )
+
+    if error:
+        _plaud_oauth_pending.pop(state, None)
+        _plaud_oauth_completed[state] = {
+            "source": source,
+            "return_to": return_to,
+            "status": "error",
+            "error": error,
+        }
+        return _plaud_redirect(source, return_to=return_to, error=error)
+
+    if not code:
+        callback_error = "no_code"
+        _plaud_oauth_pending.pop(state, None)
+        _plaud_oauth_completed[state] = {
+            "source": source,
+            "return_to": return_to,
+            "status": "error",
+            "error": callback_error,
+        }
+        return _plaud_redirect(source, return_to=return_to, error=callback_error)
+
+    from src.plaud_oauth import PlaudOAuthClient
+
+    redirect_uri = _plaud_redirect_uri(request)
+    client = PlaudOAuthClient(redirect_uri=redirect_uri)
+    try:
+        client.exchange_code_for_token(code=code, state=state)
+    except Exception as exc:
+        callback_error = str(exc)
+        _plaud_oauth_pending.pop(state, None)
+        _plaud_oauth_completed[state] = {
+            "source": source,
+            "return_to": return_to,
+            "status": "error",
+            "error": callback_error,
+        }
+        return _plaud_redirect(source, return_to=return_to, error=callback_error)
+
+    _plaud_oauth_pending.pop(state, None)
+    _plaud_oauth_completed[state] = {
+        "source": source,
+        "return_to": return_to,
+        "status": "success",
+    }
+    return _plaud_redirect(source, return_to=return_to, success=True)
 
 
 @router.post("/plaud/token", response_model=TokenStatusOut)
@@ -210,6 +301,30 @@ def _notion_redirect_uri(request: Request) -> str:
         return env_uri
     base = str(request.base_url).rstrip("/")
     return f"{base}/api/v1/auth/notion/callback"
+
+
+def _plaud_redirect_uri(request: Request) -> str:
+    """Return the public Plaud callback URI used by the API OAuth flow."""
+    env_uri = os.getenv("PLAUD_API_REDIRECT_URI")
+    if env_uri:
+        return env_uri
+    base = str(request.base_url).rstrip("/")
+    return f"{base}/api/v1/auth/plaud/callback"
+
+
+def _plaud_redirect(
+    source: str, *, return_to: str = "", success: bool = False, error: str = ""
+) -> RedirectResponse:
+    """Build the post-auth redirect for Plaud mobile/web callers."""
+    if source == "web":
+        base = return_to or "http://localhost:8050/"
+        if error:
+            return RedirectResponse(url=_append_query(base, {"plaud_error": error}))
+        return RedirectResponse(url=_append_query(base, {"plaud_connected": "1"}))
+    else:
+        if error:
+            return RedirectResponse(url=f"plaudblender://plaud-callback?error={error}")
+        return RedirectResponse(url="plaudblender://plaud-callback?success=true")
 
 
 def _notion_redirect(

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -83,7 +83,20 @@ async def system_status():
         from src.plaud_oauth import PlaudOAuthClient
 
         pc = PlaudOAuthClient()
-        result["plaud"] = {"is_authenticated": pc.is_authenticated}
+        status = dict(pc.token_status)
+        status["recovery_attempted"] = False
+
+        if status.get("has_access_token") or status.get("has_refresh_token"):
+            try:
+                pc.ensure_valid_token()
+                status = dict(pc.token_status)
+                status["recovery_attempted"] = True
+            except Exception as exc:
+                status = dict(pc.token_status)
+                status["recovery_attempted"] = True
+                status["recovery_error"] = str(exc)
+
+        result["plaud"] = status
     except Exception as e:
         result["plaud"] = {"ok": False, "error": str(e)}
 

--- a/api/routes/notion.py
+++ b/api/routes/notion.py
@@ -142,18 +142,11 @@ async def list_notion_recordings(
     Supports optional pagination via limit/offset query params.
     If limit is omitted, all recordings are returned.
     """
-    from src.chronos.notion_bridge import match_notion_to_chronos
-    from src.database import SessionLocal
-
     ns = _get_notion_service()
-    # Always fetch all pages so we know the true total and can compute real match status.
+    # Always fetch all pages so we know the true total
     pages = ns.fetch_recordings(limit=2000)
     total = len(pages)
-
-    with SessionLocal() as session:
-        match_map = match_notion_to_chronos(pages, session)
-
-    # Apply offset/limit slicing after computing the full match map.
+    # Apply offset/limit slicing
     if offset:
         pages = pages[offset:]
     if limit is not None:
@@ -173,7 +166,7 @@ async def list_notion_recordings(
                 duration=getattr(p, "duration", None),
                 tags=getattr(p, "tags", None),
                 category=getattr(p, "category", None),
-                matched_recording_id=match_map.get(p.page_id),
+                matched_recording_id=getattr(p, "matched_recording_id", None),
             )
         )
     return NotionRecordingsResponse(

--- a/api/routes/notion.py
+++ b/api/routes/notion.py
@@ -5,8 +5,10 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.schemas.responses import (
+    NotionBulkMatchOverrideRequest,
     NotionDatabaseSelectRequest,
     NotionImportRequest,
+    NotionMatchOverrideRequest,
     NotionRecordingOut,
     NotionRecordingsResponse,
     SuccessResponse,
@@ -35,12 +37,76 @@ def _get_notion_oauth():
     return NotionOAuthClient()
 
 
+BLIND_NOTION_IMPORT_LIMIT = 25
+
+
+def _build_notion_import_preview(session, sample_size: int = 25) -> dict:
+    from src.chronos.notion_bridge import (
+        collapse_exact_notion_duplicates,
+        match_notion_to_chronos,
+    )
+    from src.database.models import ChronosRecording
+
+    ns = _get_notion_service()
+    recordings = ns.fetch_recordings(limit=1000)
+
+    completed_notion = set()
+    failed_notion = set()
+    for rec in (
+        session.query(ChronosRecording)
+        .filter(ChronosRecording.source == "notion")
+        .all()
+    ):
+        if rec.recording_id.startswith("notion:"):
+            page_id = rec.recording_id[7:]
+            if rec.processing_status == "completed":
+                completed_notion.add(page_id)
+            elif rec.processing_status == "failed":
+                failed_notion.add(page_id)
+
+    matches = match_notion_to_chronos(recordings, session)
+
+    pending = []
+    matched_to_existing = 0
+    for nrec in recordings:
+        if nrec.page_id in completed_notion:
+            continue
+        if matches.get(nrec.page_id):
+            matched_to_existing += 1
+            continue
+        pending.append(nrec)
+
+    pending.sort(key=lambda n: n.date or n.created_time or "", reverse=True)
+    effective_pending, duplicate_pages_collapsed = collapse_exact_notion_duplicates(pending)
+
+    return {
+        "total_pages": len(recordings),
+        "completed_imports": len(completed_notion),
+        "failed_imports": len(failed_notion),
+        "matched_to_existing": matched_to_existing,
+        "pending_import_raw": len(pending),
+        "duplicate_pages_collapsed": duplicate_pages_collapsed,
+        "pending_import": len(effective_pending),
+        "blind_import_limit": BLIND_NOTION_IMPORT_LIMIT,
+        "blocked_without_force": len(effective_pending) > BLIND_NOTION_IMPORT_LIMIT,
+        "sample": [
+            {
+                "page_id": n.page_id,
+                "title": n.title,
+                "date": n.date or (n.created_time[:10] if n.created_time else None),
+                "url": n.url,
+            }
+            for n in effective_pending[:sample_size]
+        ],
+    }
+
+
 @router.get("/status")
 async def notion_status():
     """Notion connection status."""
     try:
         ns = _get_notion_service()
-        status = ns.check_connection(quick=True)
+        status = ns.check_connection(quick=False)
         return {
             "is_connected": status.connected if hasattr(status, "connected") else False,
             "page_count": getattr(status, "total_pages", 0),
@@ -76,11 +142,18 @@ async def list_notion_recordings(
     Supports optional pagination via limit/offset query params.
     If limit is omitted, all recordings are returned.
     """
+    from src.chronos.notion_bridge import match_notion_to_chronos
+    from src.database import SessionLocal
+
     ns = _get_notion_service()
-    # Always fetch all pages so we know the true total
+    # Always fetch all pages so we know the true total and can compute real match status.
     pages = ns.fetch_recordings(limit=2000)
     total = len(pages)
-    # Apply offset/limit slicing
+
+    with SessionLocal() as session:
+        match_map = match_notion_to_chronos(pages, session)
+
+    # Apply offset/limit slicing after computing the full match map.
     if offset:
         pages = pages[offset:]
     if limit is not None:
@@ -100,7 +173,7 @@ async def list_notion_recordings(
                 duration=getattr(p, "duration", None),
                 tags=getattr(p, "tags", None),
                 category=getattr(p, "category", None),
-                matched_recording_id=getattr(p, "matched_recording_id", None),
+                matched_recording_id=match_map.get(p.page_id),
             )
         )
     return NotionRecordingsResponse(
@@ -110,6 +183,145 @@ async def list_notion_recordings(
     )
 
 
+@router.get("/match/review")
+async def notion_match_review(limit: int = Query(default=25, ge=1, le=100)):
+    """Review high-confidence Notion match candidates and duplicate groups."""
+    from src.chronos.notion_bridge import build_notion_match_review
+    from src.database import SessionLocal
+
+    with SessionLocal() as session:
+        return build_notion_match_review(session, limit=limit)
+
+
+@router.post("/match/override", response_model=SuccessResponse)
+async def notion_match_override(body: NotionMatchOverrideRequest):
+    """Persist or clear a manual Notion → Chronos match override."""
+    from src.chronos.notion_bridge import (
+        clear_manual_notion_match_override,
+        set_manual_notion_match_override,
+    )
+    from src.database import SessionLocal
+
+    if body.clear or not body.recording_id:
+        ok, message = clear_manual_notion_match_override(body.page_id)
+        if not ok:
+            raise HTTPException(status_code=400, detail=message)
+        return SuccessResponse(message=message)
+
+    with SessionLocal() as session:
+        ok, message = set_manual_notion_match_override(
+            session,
+            page_id=body.page_id,
+            recording_id=body.recording_id,
+        )
+    if not ok:
+        raise HTTPException(status_code=400, detail=message)
+    return SuccessResponse(message=message)
+
+
+@router.post("/match/override/bulk")
+async def notion_match_override_bulk(body: NotionBulkMatchOverrideRequest):
+    """Apply multiple manual Notion → Chronos match overrides in one request."""
+    from src.chronos.notion_bridge import (
+        clear_manual_notion_match_override,
+        set_manual_notion_match_override,
+    )
+    from src.database import SessionLocal
+
+    results = []
+    applied = 0
+    cleared = 0
+    failed = 0
+
+    with SessionLocal() as session:
+        for override in body.overrides:
+            if override.clear or not override.recording_id:
+                ok, message = clear_manual_notion_match_override(override.page_id)
+                action = "clear"
+            else:
+                ok, message = set_manual_notion_match_override(
+                    session,
+                    page_id=override.page_id,
+                    recording_id=override.recording_id,
+                )
+                action = "set"
+
+            if ok:
+                if action == "clear":
+                    cleared += 1
+                else:
+                    applied += 1
+            else:
+                failed += 1
+
+            results.append(
+                {
+                    "page_id": override.page_id,
+                    "action": action,
+                    "ok": ok,
+                    "message": message,
+                }
+            )
+
+            if body.stop_on_error and not ok:
+                break
+
+    return {
+        "applied": applied,
+        "cleared": cleared,
+        "failed": failed,
+        "results": results,
+    }
+
+
+@router.get("/import/preview")
+async def notion_import_preview():
+    """Preview what the backend would import from Notion right now."""
+    from src.database import SessionLocal
+
+    with SessionLocal() as session:
+        return _build_notion_import_preview(session)
+
+
+@router.post("/import/next-batch", response_model=SuccessResponse)
+async def import_next_notion_batch(body: NotionImportRequest):
+    """Import the next safe deduped Notion batch without requiring force."""
+    from src.chronos.notion_bridge import import_all_unmatched
+    from src.database import SessionLocal
+
+    requested_batch_size = body.batch_size or BLIND_NOTION_IMPORT_LIMIT
+    if requested_batch_size < 1:
+        requested_batch_size = BLIND_NOTION_IMPORT_LIMIT
+    if requested_batch_size > BLIND_NOTION_IMPORT_LIMIT:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Safe batch import only allows batch_size<={BLIND_NOTION_IMPORT_LIMIT}."
+            ),
+        )
+
+    with SessionLocal() as session:
+        preview = _build_notion_import_preview(session)
+        pending_import = preview["pending_import"]
+        if pending_import == 0:
+            return SuccessResponse(message="No Notion pages are pending import")
+
+        imported, failed, errors = import_all_unmatched(
+            session,
+            process=body.process,
+            index=body.index,
+            batch_size=requested_batch_size,
+        )
+
+    message = (
+        f"Imported {imported} recordings from Notion using a safe batch of up to "
+        f"{requested_batch_size}"
+    )
+    if failed:
+        message += f" ({failed} failed)"
+    return SuccessResponse(message=message)
+
+
 @router.post("/import", response_model=SuccessResponse)
 async def import_from_notion(body: NotionImportRequest):
     """Import unmatched Notion recordings into Chronos."""
@@ -117,10 +329,40 @@ async def import_from_notion(body: NotionImportRequest):
     from src.database import SessionLocal
 
     with SessionLocal() as session:
-        imported, skipped, errors = import_all_unmatched(
-            session, process=body.process, index=body.index
+        preview = _build_notion_import_preview(session)
+        pending_import = preview["pending_import"]
+        requested_batch_size = max(0, body.batch_size or 0)
+
+        if pending_import > BLIND_NOTION_IMPORT_LIMIT and not body.force:
+            if requested_batch_size == 0:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Bulk Notion import blocked: {pending_import} pages are pending import. "
+                        f"Review /api/v1/notion/import/preview and retry with force=true or "
+                        f"batch_size<={BLIND_NOTION_IMPORT_LIMIT}."
+                    ),
+                )
+            if requested_batch_size > BLIND_NOTION_IMPORT_LIMIT:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Requested batch_size={requested_batch_size} exceeds the blind import limit of "
+                        f"{BLIND_NOTION_IMPORT_LIMIT}. Use force=true if you intend a large batch."
+                    ),
+                )
+
+        imported, failed, errors = import_all_unmatched(
+            session,
+            process=body.process,
+            index=body.index,
+            batch_size=requested_batch_size,
         )
-    return SuccessResponse(message=f"Imported {imported} recordings from Notion")
+
+    message = f"Imported {imported} recordings from Notion"
+    if failed:
+        message += f" ({failed} failed)"
+    return SuccessResponse(message=message)
 
 
 @router.get("/import/progress")

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import sys
+import time
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -19,6 +20,7 @@ from api.schemas.responses import (
 )
 from api.auth.jwt import require_auth
 from app_v2.services.data_service import ChronosDataService
+from src.chronos.pipeline_progress import progress, read_progress
 
 router = APIRouter(
     prefix="/api/v1/sync",
@@ -51,17 +53,43 @@ async def run_pipeline(body: PipelineRunRequest):
             detail=f"Invalid stage: {body.stage}. Must be one of {valid_stages}",
         )
 
+    current = read_progress()
+    if current and current.get("status") == "running":
+        started_at = float(current.get("started_at") or 0)
+        age_minutes = ((time.time() - started_at) / 60) if started_at else 0
+        if age_minutes < 30:
+            return PipelineRunResponse(
+                status="already_running",
+                message="Pipeline already running — watch the progress panel instead of starting another run.",
+            )
+
+        progress.finish_run(error=f"Stale run auto-cleared after {age_minutes:.0f} min")
+
     cmd = [
         sys.executable,
         "scripts/chronos_pipeline.py",
         f"--{body.stage}",
     ]
+    if body.stage in {"full", "ingest"}:
+        cmd.extend(["--days-back", str(body.days_back)])
+
     # Fire-and-forget subprocess
     subprocess.Popen(cmd, start_new_session=True)
 
     return PipelineRunResponse(
         status="started",
-        message=f"Pipeline stage '{body.stage}' started",
+        message=(
+            f"Smart sync started for the last {body.days_back} days"
+            if body.stage == "full"
+            else (
+                f"Pipeline stage '{body.stage}' started"
+                + (
+                    f" for the last {body.days_back} days"
+                    if body.stage == "ingest"
+                    else ""
+                )
+            )
+        ),
     )
 
 

--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -191,6 +191,7 @@ class StatsOut(BaseModel):
 
 class PipelineRunRequest(BaseModel):
     stage: str = "full"  # full|ingest|process|index|graph
+    days_back: int = Field(default=7, ge=1, le=365)
 
 
 class PipelineRunResponse(BaseModel):
@@ -391,6 +392,19 @@ class NotionDatabaseSelectRequest(BaseModel):
 class NotionImportRequest(BaseModel):
     process: bool = True
     index: bool = True
+    batch_size: int = 0
+    force: bool = False
+
+
+class NotionMatchOverrideRequest(BaseModel):
+    page_id: str
+    recording_id: Optional[str] = None
+    clear: bool = False
+
+
+class NotionBulkMatchOverrideRequest(BaseModel):
+    overrides: List[NotionMatchOverrideRequest]
+    stop_on_error: bool = False
 
 
 class NotionRecordingOut(BaseModel):

--- a/app_v2/callbacks/navigation.py
+++ b/app_v2/callbacks/navigation.py
@@ -1550,7 +1550,7 @@ def create_sync_view(service) -> html.Div:
                         children=[
                             html.Span("🚀", className="btn-icon"),
                             html.Span(
-                                "Full Sync (Fetch → Process → Index)",
+                                "Smart Sync (Recent Fetch → Process → Index)",
                                 className="btn-text",
                             ),
                         ],
@@ -3679,7 +3679,7 @@ def register_navigation_callbacks(app):
             xray_log(
                 "sync",
                 "start",
-                f"Kicking off a full sync — checking the last {days_back or 7} days",
+                f"Kicking off a smart sync — checking the last {days_back or 7} days",
             )
 
             # Don't start a second run if one is already going

--- a/app_v2/main.py
+++ b/app_v2/main.py
@@ -263,7 +263,7 @@ def _register_auth_routes(server):
             from src.plaud_oauth import PlaudOAuthClient
 
             client = PlaudOAuthClient()
-            return jsonify(client.token_status)
+            return jsonify(client.token_status_with_recovery(attempt_recovery=True))
         except Exception as e:
             return jsonify({"is_authenticated": False, "error": str(e)})
 

--- a/app_v2/services/data_service.py
+++ b/app_v2/services/data_service.py
@@ -2729,12 +2729,12 @@ class ChronosDataService:
         return False
 
     def get_upload_candidates(self) -> List[Dict[str, Any]]:
-        """Return list of local audio files in data/raw/usb_import/ that can be uploaded."""
+        """Return local upload candidates without blocking on Plaud cloud scans."""
         try:
             from src.plaud_client import PlaudClient
 
             client = PlaudClient()
-            return client.get_upload_candidates()
+            return client.get_upload_candidates(check_cloud=False)
         except Exception as e:
             logger.error(f"Error getting upload candidates: {e}")
             return []

--- a/deploy/systemd/chronos-api.service
+++ b/deploy/systemd/chronos-api.service
@@ -9,6 +9,7 @@ User=gunnarhostetler
 WorkingDirectory=/home/gunnarhostetler/PlaudBlender
 Environment=HOME=/home/gunnarhostetler
 Environment=PYTHONUNBUFFERED=1
+Environment=CHRONOS_API_WORKERS=2
 Environment=PATH=/home/gunnarhostetler/PlaudBlender/venv/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=/home/gunnarhostetler/PlaudBlender/.env
 ExecStart=/home/gunnarhostetler/PlaudBlender/venv/bin/python scripts/launch_api.py

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -73,8 +73,7 @@ status = client.token_status
 if not status["has_access_token"] and not status["has_refresh_token"]:
     raise SystemExit("Plaud OAuth tokens are missing")
 
-if status["needs_refresh"]:
-    client.ensure_valid_token()
+client.ensure_valid_token()
 
 print("ok")
 PY

--- a/scripts/chronos_pipeline.py
+++ b/scripts/chronos_pipeline.py
@@ -164,7 +164,11 @@ def run_preflight(*, smoke_call: bool = False) -> int:
 
 
 def run_ingest(
-    session, limit: int = 100, *, fetch_all_pages: bool = False
+    session,
+    limit: int = 100,
+    *,
+    days_back: int = 7,
+    fetch_all_pages: bool = False,
 ) -> PhaseResult:
     """Run ingestion phase: download recordings from Plaud.
 
@@ -188,7 +192,9 @@ def run_ingest(
 
     try:
         success_count, failure_count = service.ingest_recent_recordings(
-            limit=limit, fetch_all_pages=fetch_all_pages
+            limit=limit,
+            days_back=days_back,
+            fetch_all_pages=fetch_all_pages,
         )
     except Exception as e:
         error_message = str(e)
@@ -751,6 +757,12 @@ def main():
     parser.add_argument("--full", action="store_true", help="Run full pipeline")
     parser.add_argument("--limit", type=int, default=10, help="Max items per phase")
     parser.add_argument(
+        "--days-back",
+        type=int,
+        default=7,
+        help="Only ingest Plaud recordings from the last N days when paginating",
+    )
+    parser.add_argument(
         "--recording-id",
         type=str,
         default=None,
@@ -858,7 +870,10 @@ def main():
             # --full always fetches all pages; --ingest alone respects --fetch-all flag
             fetch_all = True if args.full else bool(args.fetch_all)
             ingest_result = run_ingest(
-                session, limit=args.limit, fetch_all_pages=fetch_all
+                session,
+                limit=args.limit,
+                days_back=args.days_back,
+                fetch_all_pages=fetch_all,
             )
             if ingest_result.error_message:
                 phase_errors.append(f"ingest: {ingest_result.error_message}")

--- a/scripts/launch_api.py
+++ b/scripts/launch_api.py
@@ -8,6 +8,7 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -25,6 +26,12 @@ def main():
     parser.add_argument("--host", default="0.0.0.0", help="Bind host")
     parser.add_argument("--port", type=int, default=8000, help="Bind port")
     parser.add_argument("--reload", action="store_true", help="Auto-reload on changes")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=int(os.getenv("CHRONOS_API_WORKERS", "2")),
+        help="Number of Uvicorn worker processes",
+    )
     args = parser.parse_args()
 
     import uvicorn
@@ -35,6 +42,7 @@ def main():
         host=args.host,
         port=args.port,
         reload=args.reload,
+        workers=1 if args.reload else max(1, args.workers),
     )
 
 

--- a/src/chronos/ingest_service.py
+++ b/src/chronos/ingest_service.py
@@ -8,7 +8,7 @@ never rely on transient download URLs.
 import os
 import hashlib
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List, Optional, Tuple
 from urllib.parse import urlparse
@@ -59,6 +59,80 @@ class ChronosIngestService:
         Path(self.settings.chronos_raw_audio_dir).mkdir(parents=True, exist_ok=True)
         Path(self.settings.chronos_processed_dir).mkdir(parents=True, exist_ok=True)
         Path(self.settings.chronos_graph_cache_dir).mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _comparison_timestamp(value: Optional[str]) -> Optional[datetime]:
+        """Parse Plaud timestamps into naive UTC datetimes for comparisons."""
+        if not value:
+            return None
+
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+        if parsed.tzinfo is not None:
+            return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return parsed
+
+    def _fetch_recent_recordings_window(
+        self,
+        *,
+        days_back: int,
+        page_size: int = 20,
+    ) -> Tuple[List[dict], int, str]:
+        """Fetch Plaud pages until the recent time window is fully covered.
+
+        Plaud returns at most 20 recordings per page. When callers ask for a
+        paginated ingest pass, we only keep pulling pages while recordings still
+        fall inside the requested recent window. This keeps manual "full sync"
+        useful for fresh data without hammering the entire history on every run.
+        """
+        cutoff = datetime.utcnow() - timedelta(days=days_back)
+        recordings: List[dict] = []
+        page = 1
+        pages_fetched = 0
+        stop_reason = "no Plaud recordings returned"
+
+        while True:
+            page_records = self.plaud.list_recordings(page=page, page_size=page_size)
+            if not page_records:
+                stop_reason = f"page {page} returned no recordings"
+                break
+
+            pages_fetched += 1
+            recent_records: List[dict] = []
+            older_count = 0
+
+            for rec_data in page_records:
+                record_time = self._comparison_timestamp(
+                    rec_data.get("start_at") or rec_data.get("created_at")
+                )
+                if record_time and record_time < cutoff:
+                    older_count += 1
+                    continue
+                recent_records.append(rec_data)
+
+            recordings.extend(recent_records)
+            logger.info(
+                "Fetched Plaud page %s: kept %s recent recordings, skipped %s older than %s days",
+                page,
+                len(recent_records),
+                older_count,
+                days_back,
+            )
+
+            if older_count > 0:
+                stop_reason = f"page {page} crossed the last-{days_back}-days boundary"
+                break
+
+            if len(page_records) < page_size:
+                stop_reason = f"page {page} was the final Plaud page"
+                break
+
+            page += 1
+
+        return recordings, pages_fetched, stop_reason
 
     def _compute_checksum(self, file_path: str) -> str:
         """Compute SHA256 checksum for file integrity verification.
@@ -288,7 +362,8 @@ class ChronosIngestService:
         Args:
             limit: Max recordings to fetch per batch
             days_back: Only fetch recordings from last N days
-            fetch_all_pages: If True, paginate through all recordings (ignores limit for pagination)
+            fetch_all_pages: If True, paginate through Plaud pages until the
+                recent time window is fully covered
 
         Returns:
             Tuple[int, int]: (success_count, failure_count)
@@ -310,21 +385,39 @@ class ChronosIngestService:
         try:
             _t0 = _time.perf_counter()
             if fetch_all_pages:
-                # Paginate through all recordings (using built-in pagination)
-                logger.info("Fetching ALL recordings from Plaud...")
-                xray_log("ingest", "plaud-api", "Asking Plaud for every single recording you have…")
-                recordings = self.plaud.list_recordings(fetch_all=True)
-                logger.info(f"Plaud returned {len(recordings)} total recordings")
-                # Do NOT cap with limit when fetching all — we want everything
+                logger.info(
+                    "Fetching Plaud recordings across recent pages (days_back=%s)",
+                    days_back,
+                )
+                xray_log(
+                    "ingest",
+                    "plaud-api",
+                    f"Scanning Plaud 20 at a time until we leave the last {days_back} days",
+                )
+                recordings, pages_fetched, stop_reason = (
+                    self._fetch_recent_recordings_window(
+                        days_back=days_back,
+                        page_size=20,
+                    )
+                )
+                logger.info(
+                    "Plaud returned %s recordings across %s page(s); stop reason: %s",
+                    len(recordings),
+                    pages_fetched,
+                    stop_reason,
+                )
             else:
                 # Single page fetch (most recent N only, max 20 per API)
                 page_size = min(limit, 20) if limit else 20
                 xray_log("ingest", "plaud-api", f"Asking Plaud for your newest {page_size} recordings")
                 recordings = self.plaud.list_recordings(page=1, page_size=page_size)
             _api_ms = (_time.perf_counter() - _t0) * 1000
-            xray_log("ingest", "plaud-api",
-                     f"Plaud has {len(recordings)} recordings",
-                     duration_ms=round(_api_ms, 1))
+            xray_log(
+                "ingest",
+                "plaud-api",
+                f"Plaud returned {len(recordings)} recordings inside the sync window",
+                duration_ms=round(_api_ms, 1),
+            )
         except Exception as e:
             xray_log("ingest", "plaud-api", f"Can't reach Plaud right now: {str(e)[:60]}", level="error")
             logger.error(f"Failed to fetch from Plaud API: {e}")

--- a/src/chronos/notion_bridge.py
+++ b/src/chronos/notion_bridge.py
@@ -9,6 +9,7 @@ This is the critical link that turns raw Notion pages into first-class
 Chronos citizens — searchable, graphable, analyzable.
 """
 
+import hashlib
 import logging
 import time as _time
 import uuid
@@ -222,24 +223,35 @@ def match_notion_to_chronos(
     """
     from app_v2.services.xray import xray_log
 
-    # Build a lookup of Chronos recordings by date -> list of (id, title, created_at)
+    # Build a lookup of Chronos recordings by date -> list of (id, title, created_at, transcript)
     chronos_recs = session.query(ChronosRecording).all()
-    by_date: Dict[str, List[Tuple[str, str, datetime]]] = {}
+    by_date: Dict[str, List[Tuple[str, str, datetime, str]]] = {}
     for rec in chronos_recs:
         if rec.created_at:
             date_key = rec.created_at.strftime("%Y-%m-%d") if isinstance(rec.created_at, datetime) else str(rec.created_at)[:10]
             by_date.setdefault(date_key, []).append(
-                (rec.recording_id, rec.title or "", rec.created_at)
+                (rec.recording_id, rec.title or "", rec.created_at, rec.transcript or "")
             )
 
-    # Phase 0: Direct match — pages already imported via notion:{page_id}
+    # Phase 0: Manual overrides and direct imports.
+    manual_overrides = get_manual_notion_match_overrides()
+    chronos_ids = {rec.recording_id for rec in chronos_recs}
+
     already_imported: Dict[str, str] = {}
+    for nrec in notion_recordings:
+        override_id = manual_overrides.get(nrec.page_id)
+        if override_id and override_id in chronos_ids:
+            already_imported[nrec.page_id] = override_id
+
     notion_rec_ids = {
         rec.recording_id: rec.recording_id
         for rec in chronos_recs
         if rec.recording_id.startswith("notion:")
+        and rec.processing_status == "completed"
     }
     for nrec in notion_recordings:
+        if nrec.page_id in already_imported:
+            continue
         direct_id = f"notion:{nrec.page_id}"
         if direct_id in notion_rec_ids:
             already_imported[nrec.page_id] = direct_id
@@ -253,6 +265,7 @@ def match_notion_to_chronos(
         if nrec.page_id in already_imported:
             continue  # Already matched by direct import
         notion_title = (nrec.title or "").lower().strip()
+        notion_transcript = (nrec.transcript or "").lower().strip()[:4000]
 
         # Determine the true recording date: prefer title-embedded date over page date
         fallback_date = nrec.date or (
@@ -263,7 +276,7 @@ def match_notion_to_chronos(
 
         # Phase 1: Same-date candidates
         candidates = by_date.get(notion_date, [])
-        for cid, ctitle, _ in candidates:
+        for cid, ctitle, _, ctranscript in candidates:
             ctitle_lower = (ctitle or "").lower().strip()
             if not notion_title or not ctitle_lower:
                 score = 0.4  # weak date-only match
@@ -271,6 +284,18 @@ def match_notion_to_chronos(
                 score = SequenceMatcher(None, notion_title, ctitle_lower).ratio()
             if score >= 0.45:
                 scored_pairs.append((score, nrec.page_id, cid))
+                continue
+
+            # Same-date transcript fallback for weak or missing titles.
+            chronos_transcript = (ctranscript or "").lower().strip()[:4000]
+            if notion_transcript and chronos_transcript:
+                transcript_score = SequenceMatcher(
+                    None, notion_transcript, chronos_transcript
+                ).ratio()
+                if transcript_score >= 0.75:
+                    scored_pairs.append(
+                        (0.7 + (transcript_score - 0.75), nrec.page_id, cid)
+                    )
 
         # Phase 2: Adjacent-date fuzzy match (+-1 day, penalized)
         if notion_date:
@@ -279,7 +304,7 @@ def match_notion_to_chronos(
                 nd = datetime.strptime(notion_date, "%Y-%m-%d")
                 for delta in [-1, 1]:
                     adj_date = (nd + timedelta(days=delta)).strftime("%Y-%m-%d")
-                    for cid, ctitle, _ in by_date.get(adj_date, []):
+                    for cid, ctitle, _, _ in by_date.get(adj_date, []):
                         ctitle_lower = (ctitle or "").lower().strip()
                         if notion_title and ctitle_lower:
                             score = (
@@ -309,6 +334,37 @@ def match_notion_to_chronos(
     # Merge direct imports into matches
     matches.update(already_imported)
 
+    # Phase 3: Same-date exact transcript alias match.
+    # Allow many-to-one coverage when the transcript is effectively identical.
+    alias_matches = 0
+    for nrec in notion_recordings:
+        if nrec.page_id in matches:
+            continue
+        notion_transcript = (nrec.transcript or "").lower().strip()[:4000]
+        if not notion_transcript:
+            continue
+
+        fallback_date = nrec.date or (
+            nrec.created_time[:10] if nrec.created_time else ""
+        )
+        title_date = _extract_date_from_title(nrec.title or "", fallback_date)
+        notion_date = title_date or fallback_date
+
+        best_alias: Optional[Tuple[float, str]] = None
+        for cid, _, _, ctranscript in by_date.get(notion_date, []):
+            chronos_transcript = (ctranscript or "").lower().strip()[:4000]
+            if not chronos_transcript:
+                continue
+            transcript_score = SequenceMatcher(
+                None, notion_transcript, chronos_transcript
+            ).ratio()
+            if best_alias is None or transcript_score > best_alias[0]:
+                best_alias = (transcript_score, cid)
+
+        if best_alias and best_alias[0] >= 0.97:
+            matches[nrec.page_id] = best_alias[1]
+            alias_matches += 1
+
     # Fill in unmatched Notion pages as None
     for nrec in notion_recordings:
         if nrec.page_id not in matches:
@@ -318,6 +374,7 @@ def match_notion_to_chronos(
     xray_log(
         "data", "notion-match",
         f"Matched {matched_count} of {len(notion_recordings)} Notion pages to Chronos recordings"
+        f" ({alias_matches} exact transcript aliases)"
     )
     return matches
 
@@ -540,6 +597,68 @@ _PROGRESS_FILE = os.path.join(
     "data",
     "notion_import_progress.json",
 )
+_MATCH_OVERRIDE_FILE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "data",
+    "notion_match_overrides.json",
+)
+
+
+def get_manual_notion_match_overrides() -> Dict[str, str]:
+    """Load persisted manual Notion → Chronos match overrides."""
+    try:
+        with open(_MATCH_OVERRIDE_FILE, "r") as file:
+            data = json.load(file)
+            return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_manual_notion_match_overrides(overrides: Dict[str, str]) -> None:
+    os.makedirs(os.path.dirname(_MATCH_OVERRIDE_FILE), exist_ok=True)
+    with open(_MATCH_OVERRIDE_FILE, "w") as file:
+        json.dump(overrides, file, indent=2, sort_keys=True)
+
+
+def set_manual_notion_match_override(
+    session: Session,
+    *,
+    page_id: str,
+    recording_id: str,
+) -> Tuple[bool, str]:
+    """Persist a manual Notion → Chronos match override."""
+    recording_id = (recording_id or "").strip()
+    page_id = (page_id or "").strip()
+    if not page_id:
+        return False, "page_id is required"
+    if not recording_id:
+        return False, "recording_id is required"
+
+    exists = session.query(ChronosRecording).filter(
+        ChronosRecording.recording_id == recording_id
+    ).first()
+    if not exists:
+        return False, f"Chronos recording {recording_id} was not found"
+
+    overrides = get_manual_notion_match_overrides()
+    overrides[page_id] = recording_id
+    _save_manual_notion_match_overrides(overrides)
+    return True, f"Override saved for {page_id}"
+
+
+def clear_manual_notion_match_override(page_id: str) -> Tuple[bool, str]:
+    """Remove a persisted manual Notion → Chronos match override."""
+    page_id = (page_id or "").strip()
+    if not page_id:
+        return False, "page_id is required"
+
+    overrides = get_manual_notion_match_overrides()
+    if page_id not in overrides:
+        return False, f"No override exists for {page_id}"
+
+    overrides.pop(page_id, None)
+    _save_manual_notion_match_overrides(overrides)
+    return True, f"Override cleared for {page_id}"
 
 
 def _load_progress() -> Dict:
@@ -584,6 +703,123 @@ def get_import_progress() -> Optional[Dict]:
     if not data:
         return None
     return data
+
+
+def collapse_exact_notion_duplicates(
+    recordings: List[NotionRecording],
+) -> Tuple[List[NotionRecording], int]:
+    """Collapse exact duplicate Notion transcripts to one canonical page."""
+    unique: List[NotionRecording] = []
+    seen: Set[str] = set()
+    skipped = 0
+
+    for recording in recordings:
+        transcript = (recording.transcript or '').strip()
+        if not transcript:
+            unique.append(recording)
+            continue
+
+        normalized = ' '.join(transcript.lower().split())[:6000]
+        digest = hashlib.sha1(normalized.encode('utf-8')).hexdigest()
+        if digest in seen:
+            skipped += 1
+            continue
+
+        seen.add(digest)
+        unique.append(recording)
+
+    return unique, skipped
+
+
+def build_notion_match_review(
+    session: Session,
+    *,
+    limit: int = 25,
+) -> Dict[str, Any]:
+    """Build a review payload for high-confidence Notion matching candidates."""
+    svc = get_notion_service()
+    recordings = svc.fetch_recordings(limit=1000)
+    matches = match_notion_to_chronos(recordings, session)
+
+    pending = [recording for recording in recordings if not matches.get(recording.page_id)]
+    pending.sort(key=lambda n: n.date or n.created_time or "", reverse=True)
+
+    chronos_recs = session.query(ChronosRecording).all()
+    by_date: Dict[str, List[Tuple[str, str, datetime, str]]] = {}
+    for rec in chronos_recs:
+        if rec.created_at:
+            date_key = rec.created_at.strftime("%Y-%m-%d") if isinstance(rec.created_at, datetime) else str(rec.created_at)[:10]
+            by_date.setdefault(date_key, []).append(
+                (rec.recording_id, rec.title or "", rec.created_at, rec.transcript or "")
+            )
+
+    transcript_alias_candidates = []
+    for recording in pending:
+        notion_transcript = (recording.transcript or "").lower().strip()[:4000]
+        if not notion_transcript:
+            continue
+        recording_date = recording.date or (recording.created_time[:10] if recording.created_time else "")
+        best_alias: Optional[Tuple[float, str, str]] = None
+        for candidate_id, candidate_title, _, candidate_transcript in by_date.get(recording_date, []):
+            chronos_transcript = (candidate_transcript or "").lower().strip()[:4000]
+            if not chronos_transcript:
+                continue
+            transcript_score = SequenceMatcher(
+                None, notion_transcript, chronos_transcript
+            ).ratio()
+            if best_alias is None or transcript_score > best_alias[0]:
+                best_alias = (transcript_score, candidate_id, candidate_title)
+        if best_alias and best_alias[0] >= 0.9:
+            transcript_alias_candidates.append(
+                {
+                    "page_id": recording.page_id,
+                    "title": recording.title,
+                    "date": recording_date,
+                    "candidate_recording_id": best_alias[1],
+                    "candidate_title": best_alias[2],
+                    "transcript_similarity": round(best_alias[0], 4),
+                }
+            )
+
+    transcript_alias_candidates.sort(
+        key=lambda item: item["transcript_similarity"], reverse=True
+    )
+
+    duplicate_groups: Dict[str, List[Dict[str, Optional[str]]]] = {}
+    for recording in pending:
+        transcript = (recording.transcript or "").strip()
+        if not transcript:
+            continue
+        normalized = " ".join(transcript.lower().split())[:6000]
+        digest = hashlib.sha1(normalized.encode("utf-8")).hexdigest()
+        duplicate_groups.setdefault(digest, []).append(
+            {
+                "page_id": recording.page_id,
+                "title": recording.title,
+                "date": recording.date or (recording.created_time[:10] if recording.created_time else None),
+                "url": recording.url,
+            }
+        )
+
+    duplicate_group_items = [
+        {
+            "group_size": len(group),
+            "pages": group[: min(len(group), 5)],
+        }
+        for group in duplicate_groups.values()
+        if len(group) > 1
+    ]
+    duplicate_group_items.sort(key=lambda item: item["group_size"], reverse=True)
+
+    return {
+        "pending_total": len(pending),
+        "manual_overrides": get_manual_notion_match_overrides(),
+        "manual_override_count": len(get_manual_notion_match_overrides()),
+        "high_confidence_transcript_aliases": transcript_alias_candidates[:limit],
+        "high_confidence_transcript_alias_count": len(transcript_alias_candidates),
+        "duplicate_groups": duplicate_group_items[:limit],
+        "duplicate_group_count": len(duplicate_group_items),
+    }
 
 
 def import_all_unmatched(
@@ -651,16 +887,23 @@ def import_all_unmatched(
         _clear_progress()
         return 0, 0, []
 
+    to_import, duplicate_pages_collapsed = collapse_exact_notion_duplicates(to_import)
+
     # Apply batch size limit
     if batch_size > 0:
         to_import = to_import[:batch_size]
 
     total = len(to_import)
     retrying = sum(1 for n in to_import if n.page_id in failed_notion)
+    duplicate_suffix = (
+        f"; collapsed {duplicate_pages_collapsed} exact duplicate Notion pages"
+        if duplicate_pages_collapsed
+        else ""
+    )
     xray_log(
         "data",
         "notion-import",
-        f"Importing {total} recordings ({retrying} retries) into Chronos...",
+        f"Importing {total} recordings ({retrying} retries) into Chronos{duplicate_suffix}...",
     )
 
     # Initialize progress

--- a/src/plaud_client.py
+++ b/src/plaud_client.py
@@ -105,18 +105,44 @@ class PlaudClient:
                     method, url, headers=headers, timeout=30, **kwargs
                 )
 
-                # Handle 401 - token was just validated, so this is unexpected
+                # Handle 401 by attempting a refresh before declaring auth lost.
                 if response.status_code == 401:
                     logger.warning(
-                        f"Got 401 on attempt {attempt + 1}, clearing tokens and retrying..."
+                        f"Got 401 on attempt {attempt + 1}, refreshing Plaud token and retrying..."
                     )
-                    self.oauth._clear_tokens()
+                    try:
+                        self.oauth.refresh_access_token()
+                    except Exception:
+                        self.oauth._clear_tokens()
+                        if attempt < retries - 1:
+                            time.sleep(RETRY_DELAY)
+                            continue
+                        raise AuthenticationRequired(
+                            "Authentication expired. Run: python plaud_setup.py"
+                        )
                     if attempt < retries - 1:
                         time.sleep(RETRY_DELAY)
                         continue
                     raise AuthenticationRequired(
                         "Authentication expired. Run: python plaud_setup.py"
                     )
+
+                # Handle rate limiting with exponential backoff.
+                if response.status_code == 429:
+                    retry_after = response.headers.get("Retry-After")
+                    delay = RETRY_DELAY * (attempt + 1)
+                    try:
+                        if retry_after:
+                            delay = max(delay, float(retry_after))
+                    except ValueError:
+                        pass
+                    logger.warning(
+                        f"Plaud rate limit hit on attempt {attempt + 1}; retrying in {delay:.1f}s"
+                    )
+                    last_error = "Plaud API rate limit exceeded"
+                    if attempt < retries - 1:
+                        time.sleep(delay)
+                        continue
 
                 # Handle server errors with retry
                 if response.status_code >= 500:
@@ -752,7 +778,7 @@ class PlaudClient:
         return complete_resp
 
     def get_upload_candidates(
-        self, data_dir: Optional[str] = None
+        self, data_dir: Optional[str] = None, check_cloud: bool = False
     ) -> List[Dict[str, Any]]:
         """Find local audio files that exist only locally (USB-imported, not in cloud).
 
@@ -760,6 +786,8 @@ class PlaudClient:
 
         Args:
             data_dir: Directory to scan (defaults to data/raw/usb_import/)
+            check_cloud: When True, fetch cloud recordings to mark duplicates.
+                Keep False for low-latency UI/status endpoints.
 
         Returns:
             List of dicts with path, name, size_mb, format, and cloud_status
@@ -771,16 +799,16 @@ class PlaudClient:
         if not os.path.isdir(data_dir):
             return []
 
-        # Get cloud recording names for dedup
         cloud_names = set()
-        try:
-            cloud_recs = self.list_recordings(fetch_all=True)
-            for rec in cloud_recs:
-                n = rec.get("name") or rec.get("title") or ""
-                cloud_names.add(n.strip().lower())
-        except Exception as e:
-            logger.debug("Could not fetch cloud recordings for dedup: %s", e)
-            pass
+        if check_cloud:
+            try:
+                cloud_recs = self.list_recordings(fetch_all=True)
+                for rec in cloud_recs:
+                    n = rec.get("name") or rec.get("title") or ""
+                    cloud_names.add(n.strip().lower())
+            except Exception as e:
+                logger.debug("Could not fetch cloud recordings for dedup: %s", e)
+                pass
 
         candidates = []
         audio_extensions = {".opus", ".mp3", ".wav", ".m4a", ".ogg"}
@@ -792,7 +820,7 @@ class PlaudClient:
                 continue
 
             display_name = os.path.splitext(entry.name)[0]
-            in_cloud = display_name.strip().lower() in cloud_names
+            in_cloud = display_name.strip().lower() in cloud_names if check_cloud else False
 
             candidates.append(
                 {

--- a/src/plaud_oauth.py
+++ b/src/plaud_oauth.py
@@ -322,9 +322,22 @@ class PlaudOAuthClient:
                 },
                 timeout=10,
             )
+            if response.status_code == 200:
+                return True
+            if response.status_code in {408, 425, 429} or response.status_code >= 500:
+                logger.warning(
+                    "Token validation returned transient status %s; keeping current token",
+                    response.status_code,
+                )
+                return True
             return response.status_code == 200
         except Exception as e:
             logger.debug(f"Token validation failed: {e}")
+            if self._token_expiry and datetime.now() < self._token_expiry:
+                logger.warning(
+                    "Token validation request failed transiently; keeping non-expired token"
+                )
+                return True
             return False
 
     def ensure_valid_token(self) -> str:
@@ -337,15 +350,12 @@ class PlaudOAuthClient:
         Returns:
             Valid access token string
         """
-        # Step 1: Check if we have a token that isn't expired
+        # Step 1: Use the current token while it is not near expiry.
         if self._access_token and self._token_expiry:
-            # Proactive refresh: refresh 30 mins before expiry
             if datetime.now() < self._token_expiry - timedelta(minutes=30):
-                # Token should be valid, but verify it
                 if self._validate_token():
                     return self._access_token
-                else:
-                    logger.warning("Token failed validation, attempting refresh...")
+                logger.warning("Token failed validation, attempting refresh...")
 
         # Step 2: Try to refresh if we have a refresh token
         if self._refresh_token:
@@ -354,12 +364,24 @@ class PlaudOAuthClient:
                 self.refresh_access_token()
                 if self._validate_token():
                     return self._access_token  # type: ignore[return-value]
-                else:
-                    logger.warning("Refreshed token failed validation")
+                if self._access_token and self._token_expiry:
+                    logger.warning(
+                        "Refreshed token could not be validated immediately; using refreshed token until an explicit 401 proves otherwise"
+                    )
+                    return self._access_token
+                logger.warning("Refreshed token failed validation")
             except Exception as e:
                 logger.warning(f"Token refresh failed: {e}")
 
-        # Step 3: Clear invalid tokens and require re-authentication
+        # Step 3: If we still hold a non-expired token, use it and let the
+        # actual API request decide via 401 whether re-auth is needed.
+        if self._access_token and self._token_expiry and datetime.now() < self._token_expiry:
+            logger.warning(
+                "Falling back to cached non-expired Plaud token after validation problems"
+            )
+            return self._access_token
+
+        # Step 4: No usable token remains.
         self._clear_tokens()
         raise AuthenticationRequired(
             "Authentication required. Run: python plaud_setup.py\n"
@@ -436,6 +458,42 @@ class PlaudOAuthClient:
             status["token_valid"] = now < self._token_expiry
 
         return status
+
+    def token_status_with_recovery(self, *, attempt_recovery: bool = True) -> dict:
+        """Return token status and optionally auto-recover via refresh token.
+
+        This is safe for API status endpoints that should self-heal whenever a
+        refresh token is available.
+        """
+        status = dict(self.token_status)
+        status["recovery_attempted"] = False
+
+        if not attempt_recovery:
+            return status
+
+        has_refresh = bool(status.get("has_refresh_token"))
+        should_recover = has_refresh and (
+            not status.get("has_access_token")
+            or not status.get("is_authenticated")
+            or bool(status.get("needs_refresh"))
+        )
+
+        if not should_recover:
+            return status
+
+        status["recovery_attempted"] = True
+        try:
+            self.ensure_valid_token()
+            recovered = dict(self.token_status)
+            recovered["recovery_attempted"] = True
+            recovered["recovered"] = True
+            return recovered
+        except Exception as exc:
+            failed = dict(self.token_status)
+            failed["recovery_attempted"] = True
+            failed["recovered"] = False
+            failed["recovery_error"] = str(exc)
+            return failed
 
     def _open_browser_chrome_first(self, url: str):
         """Try Chrome first (better localhost handling), then fall back to default."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ Tests every route for success, 404, 401, and invalid input paths.
 """
 
 import os
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
@@ -331,6 +332,47 @@ class TestHealth:
         r = authed_client.get("/api/v1/health")
         assert r.status_code == 200
 
+    def test_status_attempts_plaud_recovery(self, client):
+        with patch("src.plaud_oauth.PlaudOAuthClient") as MockPlaud:
+            instance = MockPlaud.return_value
+            instance.token_status = {
+                "is_authenticated": True,
+                "has_access_token": True,
+                "has_refresh_token": True,
+                "token_valid": True,
+                "expires_at": "2026-12-31T00:00:00",
+                "expires_in_minutes": 60,
+                "needs_refresh": False,
+            }
+
+            r = client.get("/api/v1/status")
+            assert r.status_code == 200
+            data = r.json()
+            assert data["plaud"]["is_authenticated"] is True
+            assert data["plaud"]["recovery_attempted"] is True
+            instance.ensure_valid_token.assert_called_once()
+
+    def test_status_reports_plaud_recovery_failure(self, client):
+        with patch("src.plaud_oauth.PlaudOAuthClient") as MockPlaud:
+            instance = MockPlaud.return_value
+            instance.token_status = {
+                "is_authenticated": False,
+                "has_access_token": True,
+                "has_refresh_token": True,
+                "token_valid": False,
+                "expires_at": "2026-12-31T00:00:00",
+                "expires_in_minutes": -5,
+                "needs_refresh": True,
+            }
+            instance.ensure_valid_token.side_effect = Exception("refresh failed")
+
+            r = client.get("/api/v1/status")
+            assert r.status_code == 200
+            data = r.json()
+            assert data["plaud"]["is_authenticated"] is False
+            assert data["plaud"]["recovery_attempted"] is True
+            assert data["plaud"]["recovery_error"] == "refresh failed"
+
 
 # ═══════════════════════════════════════════════════════════
 # AUTH (test auth enforcement)
@@ -637,6 +679,18 @@ class TestSync:
             assert data["status"] == "started"
             mock_popen.assert_called_once()
 
+    def test_run_pipeline_when_already_running(self, client):
+        running = {"status": "running", "started_at": time.time()}
+        with (
+            patch("api.routes.sync.read_progress", return_value=running),
+            patch("subprocess.Popen") as mock_popen,
+        ):
+            r = client.post("/api/v1/sync/run", json={"stage": "full"})
+            assert r.status_code == 200
+            data = r.json()
+            assert data["status"] == "already_running"
+            mock_popen.assert_not_called()
+
     def test_run_pipeline_invalid_stage(self, client):
         r = client.post("/api/v1/sync/run", json={"stage": "invalid"})
         assert r.status_code == 400
@@ -849,6 +903,19 @@ class TestAuthEndpoints:
             assert "auth_url" in data
             assert data["state"] == "state123"
 
+    def test_plaud_authorize_mobile_uses_api_callback(self, client, monkeypatch):
+        monkeypatch.delenv("PLAUD_API_REDIRECT_URI", raising=False)
+        with patch("src.plaud_oauth.PlaudOAuthClient") as MockPlaud:
+            MockPlaud.return_value.get_authorization_url.return_value = (
+                "https://example.com/auth",
+                "state123",
+            )
+            r = client.get("/api/v1/auth/plaud/authorize?mobile=true")
+            assert r.status_code == 200
+            MockPlaud.assert_called_once_with(
+                redirect_uri="http://testserver/api/v1/auth/plaud/callback"
+            )
+
     def test_plaud_token_exchange(self, client):
         with patch("src.plaud_oauth.PlaudOAuthClient") as MockPlaud:
             MockPlaud.return_value.token_status = {
@@ -871,6 +938,43 @@ class TestAuthEndpoints:
                 json={"code": "bad", "state": "state"},
             )
             assert r.status_code == 400
+
+    def test_plaud_callback_mobile_redirects_to_app(self, client):
+        with patch("src.plaud_oauth.PlaudOAuthClient") as MockPlaud:
+            MockPlaud.return_value.get_authorization_url.return_value = (
+                "https://example.com/auth",
+                "state123",
+            )
+            r = client.get("/api/v1/auth/plaud/authorize?mobile=true")
+            assert r.status_code == 200
+
+            r = client.get(
+                "/api/v1/auth/plaud/callback?code=authcode123&state=state123",
+                follow_redirects=False,
+            )
+            assert r.status_code in (302, 307)
+            assert r.headers["location"] == "plaudblender://plaud-callback?success=true"
+
+    def test_plaud_callback_web_redirects_back_to_browser(self, client):
+        with patch("src.plaud_oauth.PlaudOAuthClient") as MockPlaud:
+            MockPlaud.return_value.get_authorization_url.return_value = (
+                "https://example.com/auth",
+                "state123",
+            )
+            r = client.get(
+                "/api/v1/auth/plaud/authorize?return_to=http://localhost:8050/settings"
+            )
+            assert r.status_code == 200
+
+            r = client.get(
+                "/api/v1/auth/plaud/callback?code=authcode123&state=state123",
+                follow_redirects=False,
+            )
+            assert r.status_code in (302, 307)
+            assert (
+                r.headers["location"]
+                == "http://localhost:8050/settings?plaud_connected=1"
+            )
 
     def test_plaud_refresh(self, client):
         with patch("src.plaud_oauth.PlaudOAuthClient") as MockPlaud:

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+
+def test_fetch_all_pages_stops_once_recent_window_is_covered(monkeypatch):
+    from app_v2.services import xray as xray_module
+    from src.chronos.ingest_service import ChronosIngestService
+
+    monkeypatch.setattr(xray_module, "xray_log", lambda *args, **kwargs: None)
+
+    now = datetime.utcnow()
+
+    def rec(recording_id: str, days_ago: int) -> dict:
+        timestamp = (now - timedelta(days=days_ago)).replace(
+            microsecond=0
+        ).isoformat() + "Z"
+        return {
+            "id": recording_id,
+            "start_at": timestamp,
+            "created_at": timestamp,
+            "duration": 60_000,
+            "serial_number": "plaud-note",
+            "name": recording_id,
+        }
+
+    page_1 = [rec(f"recent-a-{index}", 0) for index in range(20)]
+    page_2 = [rec(f"recent-b-{index}", 3) for index in range(20)]
+    page_3 = [rec(f"old-{index}", 10) for index in range(20)]
+
+    plaud_client = MagicMock()
+    plaud_client.oauth.is_authenticated = True
+    plaud_client.list_recordings.side_effect = [page_1, page_2, page_3]
+
+    service = ChronosIngestService(db_session=MagicMock(), plaud_client=plaud_client)
+    monkeypatch.setattr(service, "ingest_recording", lambda **kwargs: (True, None))
+
+    success, failed = service.ingest_recent_recordings(
+        days_back=7,
+        fetch_all_pages=True,
+    )
+
+    assert success == 40
+    assert failed == 0
+    assert plaud_client.list_recordings.call_count == 3

--- a/tests/test_services_smoke.py
+++ b/tests/test_services_smoke.py
@@ -301,6 +301,101 @@ class TestPlaudOAuth:
         assert state in url
         assert len(state) > 16  # secrets.token_urlsafe(32) is ~43 chars
 
+    def test_refresh_keeps_token_when_post_refresh_validation_is_transient(self):
+        """Do not discard a freshly refreshed token just because validation is flaky."""
+        from datetime import datetime, timedelta
+        from unittest.mock import patch
+        from src.plaud_oauth import PlaudOAuthClient
+
+        with patch.dict(
+            "os.environ",
+            {
+                "PLAUD_CLIENT_ID": "test_client_id",
+                "PLAUD_CLIENT_SECRET": "test_client_secret",
+            },
+        ):
+            client = PlaudOAuthClient(
+                redirect_uri="https://localhost:8050/auth/plaud/callback"
+            )
+
+        client._access_token = "old-token"
+        client._refresh_token = "refresh-token"
+        client._token_expiry = datetime.now() + timedelta(minutes=5)
+
+        def _fake_refresh():
+            client._access_token = "new-token"
+            client._token_expiry = datetime.now() + timedelta(hours=1)
+
+        with (
+            patch.object(client, "refresh_access_token", side_effect=_fake_refresh),
+            patch.object(client, "_validate_token", side_effect=[False, False]),
+            patch.object(client, "_clear_tokens") as clear_tokens,
+        ):
+            token = client.ensure_valid_token()
+
+        assert token == "new-token"
+        clear_tokens.assert_not_called()
+
+
+class TestPlaudClientAuthResilience:
+    """Regression tests for resilient Plaud API auth handling."""
+
+    def test_request_retries_after_429(self):
+        from unittest.mock import MagicMock, patch
+        from src.plaud_client import PlaudClient
+
+        oauth = MagicMock()
+        oauth.ensure_valid_token.return_value = "token"
+        client = PlaudClient(oauth_client=oauth)
+
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.headers = {"Retry-After": "0"}
+        rate_limited.raise_for_status.side_effect = Exception("should not be raised")
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.headers = {}
+        ok.json.return_value = {"ok": True}
+        ok.raise_for_status.return_value = None
+
+        with (
+            patch("src.plaud_client.requests.request", side_effect=[rate_limited, ok]),
+            patch("src.plaud_client.time.sleep") as sleep_mock,
+        ):
+            result = client._request("GET", "/users/current", retries=2)
+
+        assert result == {"ok": True}
+        sleep_mock.assert_called()
+
+    def test_request_refreshes_on_401_before_failing(self):
+        from unittest.mock import MagicMock, patch
+        from src.plaud_client import PlaudClient
+
+        oauth = MagicMock()
+        oauth.ensure_valid_token.return_value = "token"
+        client = PlaudClient(oauth_client=oauth)
+
+        unauthorized = MagicMock()
+        unauthorized.status_code = 401
+        unauthorized.headers = {}
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.headers = {}
+        ok.json.return_value = {"ok": True}
+        ok.raise_for_status.return_value = None
+
+        with (
+            patch("src.plaud_client.requests.request", side_effect=[unauthorized, ok]),
+            patch("src.plaud_client.time.sleep"),
+        ):
+            result = client._request("GET", "/users/current", retries=2)
+
+        assert result == {"ok": True}
+        oauth.refresh_access_token.assert_called_once()
+        oauth._clear_tokens.assert_not_called()
+
 
 class TestPlaudWorkflow:
     """Tests for src/plaud_workflow.py."""


### PR DESCRIPTION
This PR promotes the current tested live Pi backend state into `main` so GitHub becomes the canonical source of truth for Chronos again.

Summary:
- bring the current live Pi backend code into `main`
- include Smart Sync behavior for safer recent-window Plaud syncs
- preserve the Pi-only auth and Notion route fixes that were validated on the Pi
- include the targeted API and ingest test updates that cover the Smart Sync behavior

Why:
- the Pi had become the place where the real running backend state lived
- this PR reconciles that drift back into GitHub history so `main` can become the canonical backend branch
- it preserves the live tested state instead of reconstructing it from memory

Validation:
- ran `pytest tests/test_api.py tests/test_ingest_service.py -q` on the Pi baseline branch
- result: `80 passed`
- live Pi API health verified after deployment and restart

Notes:
- this PR is based on `pi-live-current-20260428`, which captures the exact current live Pi backend state after Smart Sync deployment and Pi-only route cleanup
- after merge, the next cleanup step is to repoint the live Pi checkout to merged `main` so the deployment machine is no longer a dirty snowflake

## Summary by Sourcery

Promote the current Pi backend state into main by hardening Plaud auth and ingest flows, tightening Notion import/matching safety, and wiring UI and orchestration around a new smart recent-window sync.

New Features:
- Add manual Notion→Chronos match override storage and API endpoints, plus review payloads for high-confidence transcript matches and duplicate detection.
- Introduce safe, deduplicated Notion import preview and batch import endpoints with configurable limits.
- Add Plaud OAuth mobile/web callback handling that redirects back into the app or browser and supports OPTIONS preflight.
- Expose a smart sync pipeline trigger that passes a configurable recent-days window into the ingest phase and surfaces more descriptive messages in the UI.

Bug Fixes:
- Prevent duplicate Chronos sync runs by detecting an already-running pipeline and auto-clearing stale runs.
- Avoid misclassifying Plaud tokens as invalid when validation fails transiently, and ensure refreshed tokens are retained until a hard failure.
- Stop UI upload-candidate checks from blocking on Plaud cloud scans by default.

Enhancements:
- Improve Notion matching by incorporating transcripts, collapsing exact-duplicate Notion pages, and logging alias matches in xray.
- Add Plaud ingest logic that paginates only within a recent time window instead of re-syncing the entire history on each run.
- Make Plaud client more resilient with token-refresh-on-401 behavior and rate-limit-aware retries with backoff.
- Warm Plaud auth status on API startup and surface richer, self-healing Plaud status in health and status endpoints.
- Tighten Plaud OAuth handling in the Dash app and backend by using shared recovery-aware token status helpers.

Tests:
- Expand API and service smoke tests to cover Plaud recovery behavior, OAuth callback flows, pipeline run idempotency, Plaud client retry semantics, and the recent-window Plaud ingest logic.
- Add targeted ingest service tests to ensure the recent-window pagination stops after the covered time range.