### PR TITLE
🧹 Remove unused json import in webhook server

### DIFF
--- a/src/plaud_webhook_server.py
+++ b/src/plaud_webhook_server.py
@@ -14,7 +14,6 @@ Usage:
 """
 
 import os
-import json
 import logging
 import threading
 from datetime import datetime, timedelta
@@ -35,7 +34,6 @@ from .config import get_settings
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
-
 @dataclass
 class EventLogEntry:
     """A logged webhook event."""
@@ -53,7 +51,6 @@ class EventLogEntry:
             "processed": self.processed,
             "data": self.event.data,
         }
-
 
 class PlaudWebhookServer:
     """
@@ -346,10 +343,8 @@ class PlaudWebhookServer:
         except:
             return None
 
-
 # Singleton instance
 _webhook_server: Optional[PlaudWebhookServer] = None
-
 
 def get_webhook_server() -> PlaudWebhookServer:
     """Get the singleton webhook server instance."""
@@ -357,7 +352,6 @@ def get_webhook_server() -> PlaudWebhookServer:
     if _webhook_server is None:
         _webhook_server = PlaudWebhookServer()
     return _webhook_server
-
 
 def start_webhook_server(port: int = 8090) -> PlaudWebhookServer:
     """
@@ -375,7 +369,6 @@ def start_webhook_server(port: int = 8090) -> PlaudWebhookServer:
     if not _webhook_server.is_running:
         _webhook_server.start()
     return _webhook_server
-
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
🎯 **What:** Removed unused `json` import from `src/plaud_webhook_server.py`.
💡 **Why:** Unused imports increase clutter, can create confusion about dependencies, and should be removed as a general clean-up practice to improve code maintainability and readability.
✅ **Verification:** Validated that the file still imports successfully and verified there are no unused dependencies on the `json` module.
✨ **Result:** A slightly cleaner and more maintainable `plaud_webhook_server.py`.

---
*PR created automatically by Jules for task [2435448638800283396](https://jules.google.com/task/2435448638800283396) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove redundant blank lines in the Plaud webhook server module to streamline formatting.