### PR TITLE
🧹 Remove unused LargeBinary import in models

### DIFF
--- a/src/database/models.py
+++ b/src/database/models.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Text,
     DateTime,
     JSON,
-    LargeBinary,
 )
 from sqlalchemy.orm import declarative_base, relationship
 


### PR DESCRIPTION
🎯 What: Removed the `LargeBinary` import from `src/database/models.py`.
💡 Why: This is a code health improvement to clean up unused ORM types, improving maintainability and readability.
✅ Verification: Ran the full test suite (`pytest`) to ensure no regressions were introduced. All tests passed.
✨ Result: The codebase is cleaner with no impact on functionality.

---
*PR created automatically by Jules for task [8045563918447729705](https://jules.google.com/task/8045563918447729705) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove an unused LargeBinary import from the database models module to improve code cleanliness and maintainability.