### PR TITLE
🧹 Remove unused ScrollRequest import in cleanup_qdrant

### DIFF
--- a/scripts/cleanup_qdrant.py
+++ b/scripts/cleanup_qdrant.py
@@ -1,7 +1,6 @@
 """Clean orphan Qdrant points that no longer have matching SQLite events."""
 from sqlalchemy import create_engine, text
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import ScrollRequest
 
 e = create_engine("sqlite:///data/brain.db")
 q = QdrantClient(url="http://localhost:6333")


### PR DESCRIPTION
🎯 **What:** Removed unused `ScrollRequest` import in `cleanup_qdrant.py`.
💡 **Why:** Dead code clutters the script and removing it improves codebase readability and maintainability.
✅ **Verification:** Ran `pyright` to ensure no typing failures and `pytest` test suite to check that no core functionality was broken.
✨ **Result:** Cleaned codebase with no change in functionality.

---
*PR created automatically by Jules for task [12463741909365626952](https://jules.google.com/task/12463741909365626952) started by @Gunnarguy*

## Summary by Sourcery

Chores:
- Clean up an unused ScrollRequest import from cleanup_qdrant.py with no functional changes.