### PR TITLE
🧹 [Code Health] Remove unused or_ import in chronos_repository.py

### DIFF
--- a/src/database/chronos_repository.py
+++ b/src/database/chronos_repository.py
@@ -7,7 +7,7 @@ legacy Recording/Segment logic.
 
 from datetime import datetime
 from typing import Any, List, Optional
-from sqlalchemy import and_, or_
+from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from .models import (


### PR DESCRIPTION
🎯 **What:** Removed unused `or_` import from `sqlalchemy` in `src/database/chronos_repository.py`.
💡 **Why:** Cleans up dependency noise and improves maintainability by removing unused code.
✅ **Verification:** Ran pytest tests successfully.
✨ **Result:** Improved codebase cleanliness without changing functionality.

---
*PR created automatically by Jules for task [3463694913872507710](https://jules.google.com/task/3463694913872507710) started by @Gunnarguy*

## Summary by Sourcery

Chores:
- Clean up an unused `or_` import in `src/database/chronos_repository.py` without changing functionality.