### PR TITLE
🧹 [code health] Remove unused DayOfWeek import in engine

### DIFF
--- a/src/chronos/engine.py
+++ b/src/chronos/engine.py
@@ -17,7 +17,6 @@ from src.config import get_settings
 from src.models.chronos_schemas import (
     ChronosEvent,
     GeminiEventOutput,
-    DayOfWeek,
     EventCategory,
 )
 


### PR DESCRIPTION
🎯 **What:** Removed unused `DayOfWeek` import from `src/chronos/engine.py`.
💡 **Why:** Removing unused local schema imports prevents circular dependencies and cleans up code, improving maintainability.
✅ **Verification:** Ran `pytest` tests successfully and verified no behavior change.
✨ **Result:** A cleaner codebase without an unnecessary import.

---
*PR created automatically by Jules for task [9493726635394794745](https://jules.google.com/task/9493726635394794745) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Simplify the chronos engine module by removing an unused DayOfWeek import to avoid unnecessary local schema dependencies.