### PR TITLE
🧹 Remove unused EventCategory and DayOfWeek imports from engine.py

### DIFF
--- a/src/chronos/engine.py
+++ b/src/chronos/engine.py
@@ -17,8 +17,6 @@ from src.config import get_settings
 from src.models.chronos_schemas import (
     ChronosEvent,
     GeminiEventOutput,
-    DayOfWeek,
-    EventCategory,
 )
 
 from src.chronos.genai_helpers import (


### PR DESCRIPTION
🎯 **What:** Removed unused `EventCategory` and `DayOfWeek` imports from `src/chronos/engine.py`.
💡 **Why:** To improve code maintainability and readability by cleaning up dead code.
✅ **Verification:** Verified by running the full test suite.
✨ **Result:** Cleaner codebase without unused imports.

---
*PR created automatically by Jules for task [13371530533821228828](https://jules.google.com/task/13371530533821228828) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove unused EventCategory and DayOfWeek imports from the engine module to reduce dead code.