### PR TITLE
Fix stuck recording reset for failed recordings without transcripts

### DIFF
--- a/scripts/fix_recordings.py
+++ b/scripts/fix_recordings.py
@@ -111,12 +111,12 @@ if "--fix" in sys.argv:
     cur.execute(
         """
         UPDATE chronos_recordings
-        SET processing_status = 'pending', error_message = NULL
+        SET error_message = NULL
         WHERE processing_status = 'failed'
         AND (transcript IS NULL OR LENGTH(transcript) < 100)
     """
     )
-    print(f"  Reset {cur.rowcount} failed recordings without transcripts to 'pending'")
+    print(f"  Cleared errors for {cur.rowcount} failed recordings without transcripts")
 
     conn.commit()
 


### PR DESCRIPTION
This PR fixes a bug in `scripts/fix_recordings.py` where failed recordings without transcripts are incorrectly reset to 'pending' state. This update clears the error messages for these recordings while properly keeping their processing status as 'failed'.

---
*PR created automatically by Jules for task [18393844499038427722](https://jules.google.com/task/18393844499038427722) started by @Gunnarguy*

## Summary by Sourcery

Bug Fixes:
- Stop resetting failed recordings without transcripts back to 'pending' status while still clearing their error messages.