### PR TITLE
🧹 [Code Health] Remove unused os import in plaud_auto_sync.py

### DIFF
--- a/src/plaud_auto_sync.py
+++ b/src/plaud_auto_sync.py
@@ -14,7 +14,6 @@ Usage:
     sync_service.start()
 """
 
-import os
 import logging
 import threading
 import subprocess


### PR DESCRIPTION
🎯 **What:** Removed an unused `os` import from `src/plaud_auto_sync.py`.
💡 **Why:** Removing unused imports reduces clutter, avoids unnecessary namespace pollution, and improves the overall readability and maintainability of the codebase. It also helps tools like `flake8` report a cleaner bill of health.
✅ **Verification:** I ran `flake8` to identify unused imports and other linting issues. I removed the unused `import os` on line 17 and ran the full pytest test suite to ensure that no functionality was broken. All tests passed successfully.
✨ **Result:** The codebase is cleaner and one minor code health issue has been effectively addressed with zero risk of breaking functionality.

---
*PR created automatically by Jules for task [17794694409102030824](https://jules.google.com/task/17794694409102030824) started by @Gunnarguy*

## Summary by Sourcery

Chores:
- Clean up unused os import from plaud_auto_sync.py.