### PR TITLE
🔒 Fix Overly Permissive CORS Configuration

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -18,13 +18,13 @@ Run:
     uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload
 """
 
-from contextlib import asynccontextmanager
-import logging
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
+from contextlib import asynccontextmanager  # noqa: E402
+import logging  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
+from fastapi.middleware.gzip import GZipMiddleware  # noqa: E402
 
-from src.database import init_db
+from src.database import init_db  # noqa: E402
 
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ app.add_middleware(
         "http://localhost:8050",
         "http://localhost:8000",
     ],
-    allow_origin_regex=r"^http://(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.).*",
+    allow_origin_regex=r"^https?://(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3})(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,34 @@
+import re
+
+# The new regex implemented in api/main.py
+CORS_REGEX = r"^https?://(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3})(:\d+)?$"
+
+def test_cors_regex_valid_origins():
+    valid_origins = [
+        "http://10.0.0.1",
+        "https://10.0.0.1",
+        "http://10.255.255.255:3000",
+        "http://192.168.1.100",
+        "https://192.168.1.100:8000",
+        "http://172.16.0.1",
+        "http://172.31.255.255",
+        "https://172.20.10.5:8080",
+    ]
+    for origin in valid_origins:
+        assert re.match(CORS_REGEX, origin) is not None, f"Expected {origin} to be valid"
+
+def test_cors_regex_invalid_origins():
+    invalid_origins = [
+        "http://10.attacker.com",
+        "http://192.168.com",
+        "https://192.168.attacker.com",
+        "http://172.32.0.1",
+        "http://172.15.255.255",
+        "http://10.0.0.1.attacker.com",
+        "http://192.168.1.100.com",
+        "http://10.0.0.1:3000/path",  # Origin header doesn't contain path
+        "ftp://10.0.0.1",
+        "http://evil10.0.0.1",
+    ]
+    for origin in invalid_origins:
+        assert re.match(CORS_REGEX, origin) is None, f"Expected {origin} to be invalid"


### PR DESCRIPTION
🎯 What:
The CORS configuration in `api/main.py` previously used an overly permissive regex (`^http://(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.).*`) that could match arbitrary subdomains containing private IP prefixes (e.g., `http://10.attacker.com`). Since `allow_credentials=True` is set, this is a significant security risk.

⚠️ Risk:
An attacker could register a domain that happens to start with a local IP prefix, bypassing the CORS restriction. If a user visits this malicious domain, the attacker's site could make cross-origin requests to the application, exposing session tokens or other sensitive user data.

🛡️ Solution:
Replaced the permissive regex with a stricter pattern: `^https?://(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3})(:\d+)?$`. This ensures that only valid IPv4 private network addresses (and optionally their port numbers) are accepted as origins. We also added unit tests in `tests/test_cors.py` to strictly validate and verify the new regex behavior.

---
*PR created automatically by Jules for task [2832081609541712484](https://jules.google.com/task/2832081609541712484) started by @Gunnarguy*

## Summary by Sourcery

Tighten CORS origin validation to only allow explicit private IPv4 network origins and add coverage to guard the new behavior.

Bug Fixes:
- Prevent CORS from accepting attacker-controlled domains that merely start with private IP prefixes when credentials are allowed.

Tests:
- Add unit tests verifying that the CORS origin regex accepts valid private-network origins and rejects malformed or attacker-controlled origins.

Chores:
- Add noqa E402 annotations to top-level imports in api/main.py to satisfy linting for import placement.