### PR TITLE
🔒 Fix Command Injection Vulnerability in admin.py

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -169,16 +169,16 @@ async def ensure_public_stack():
 @router.post("/stack/restart-public", response_model=StackControlResponse)
 async def restart_public_stack():
     LOG_DIR.mkdir(parents=True, exist_ok=True)
-    command = (
-        f"cd {ROOT} && "
-        "(sleep 1; bash ./chronos stop; bash ./chronos start) "
-        f">> {LOG_DIR / 'admin-restart.log'} 2>&1"
-    )
+    log_file_path = LOG_DIR / "admin-restart.log"
+    log_file = open(log_file_path, "a")
     subprocess.Popen(
-        ["/bin/sh", "-c", command],
+        ["bash", "-c", "sleep 1; bash ./chronos stop; bash ./chronos start"],
         cwd=str(ROOT),
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
         start_new_session=True,
     )
+    log_file.close()
     return StackControlResponse(
         action="restart-public",
         status="scheduled",


### PR DESCRIPTION
🎯 What: Fixed a command injection vulnerability in restart_public_stack where paths were unsafely interpolated into a shell command.
⚠️ Risk: If the path components were ever user-controllable or contained shell metacharacters, arbitrary code execution would be possible.
🛡️ Solution: Removed the shell interpolation. Changed the directory by passing cwd to subprocess.Popen and handled log file output natively through Python file objects instead of shell redirection.

---
*PR created automatically by Jules for task [15398134458485392309](https://jules.google.com/task/15398134458485392309) started by @Gunnarguy*

## Summary by Sourcery

Fix command execution in the public stack restart endpoint to avoid shell-based path interpolation and potential command injection.

Bug Fixes:
- Eliminate shell command interpolation in restart_public_stack by using subprocess.Popen with a fixed command and working directory.
- Route admin restart logs through Python-managed file handles instead of shell redirection to prevent unsafe injection vectors.