### PR TITLE
🧹 [code health improvement] Remove unused datetime import

### DIFF
--- a/src/chronos/qdrant_client.py
+++ b/src/chronos/qdrant_client.py
@@ -7,7 +7,6 @@ and temporal search capabilities required by the Chronos architecture.
 import logging
 import time as _time
 from typing import List, Optional, Dict, Any
-from datetime import datetime
 
 from qdrant_client import QdrantClient
 from qdrant_client.models import (


### PR DESCRIPTION
🎯 What: Removed the unused import 'from datetime import datetime' in 'src/chronos/qdrant_client.py'.
💡 Why: Improves code maintainability and readability by eliminating dead code.
✅ Verification: Ran the full test suite ('python -m pytest') to ensure the removal was safe and didn't introduce any regressions. Verified via 'git diff --cached' that only the unused import was removed.
✨ Result: Cleaner code in 'qdrant_client.py' without any loss of functionality.

---
*PR created automatically by Jules for task [16271203432148069193](https://jules.google.com/task/16271203432148069193) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Clean up dead code in qdrant_client.py by removing an unused datetime import.