### PR TITLE
🧹 Remove unused os import from test_all.py

### DIFF
--- a/test_all.py
+++ b/test_all.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-import os
 
 repo_dir = "/Users/gunnarhostetler/Documents/GitHub/PlaudBlender_wt"
 json_path = "/Users/gunnarhostetler/.gemini/antigravity-ide/brain/4e97d00f-bb33-4258-8864-f89291e20c1a/.system_generated/steps/12/output.txt"


### PR DESCRIPTION
🎯 **What:** Removed unused `import os` in `test_all.py`.
💡 **Why:** Reduces clutter and improves code maintainability.
✅ **Verification:** Verified by running the full test suite (`python -m pytest tests/`).
✨ **Result:** A cleaner `test_all.py` file without changing behavior.

---
*PR created automatically by Jules for task [16970055133629395847](https://jules.google.com/task/16970055133629395847) started by @Gunnarguy*

## Summary by Sourcery

Chores:
- Remove an unused os import from test_all.py to reduce clutter.