### PR TITLE
🧹 Code health: Remove unused PlaudWebhookHandler import

### DIFF
--- a/src/plaud_webhook_server.py
+++ b/src/plaud_webhook_server.py
@@ -24,7 +24,6 @@ from queue import Queue
 from flask import Flask, request, jsonify
 
 from .plaud_webhook import (
-    PlaudWebhookHandler,
     PlaudEvent,
     PlaudEventType,
     get_webhook_handler,
@@ -33,6 +32,7 @@ from .config import get_settings
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
 
 @dataclass
 class EventLogEntry:
@@ -51,6 +51,7 @@ class EventLogEntry:
             "processed": self.processed,
             "data": self.event.data,
         }
+
 
 class PlaudWebhookServer:
     """
@@ -340,11 +341,13 @@ class PlaudWebhookServer:
                 return self.event_queue.get(timeout=timeout)
             else:
                 return self.event_queue.get_nowait()
-        except:
+        except Exception:
             return None
+
 
 # Singleton instance
 _webhook_server: Optional[PlaudWebhookServer] = None
+
 
 def get_webhook_server() -> PlaudWebhookServer:
     """Get the singleton webhook server instance."""
@@ -352,6 +355,7 @@ def get_webhook_server() -> PlaudWebhookServer:
     if _webhook_server is None:
         _webhook_server = PlaudWebhookServer()
     return _webhook_server
+
 
 def start_webhook_server(port: int = 8090) -> PlaudWebhookServer:
     """
@@ -369,6 +373,7 @@ def start_webhook_server(port: int = 8090) -> PlaudWebhookServer:
     if not _webhook_server.is_running:
         _webhook_server.start()
     return _webhook_server
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
🎯 **What:** Removed the unused `PlaudWebhookHandler` import from `src/plaud_webhook_server.py`. Also changed a bare `except:` to `except Exception:` and ran formatting.
💡 **Why:** Removing unused imports reduces clutter and improves the maintainability and readability of the codebase without changing any behavior. The bare except fix prevents catching `SystemExit` or `KeyboardInterrupt`.
✅ **Verification:** Verified by checking that all linting checks (using `ruff`) and the test suite (`pytest`) pass locally without errors.
✨ **Result:** A cleaner codebase with fewer unused dependencies, adhering to formatting standards.

---
*PR created automatically by Jules for task [392493295381130370](https://jules.google.com/task/392493295381130370) started by @Gunnarguy*

## Summary by Sourcery

Clean up Plaud webhook server module and tighten exception handling.

Bug Fixes:
- Restrict a bare exception handler in the Plaud webhook server to catch only standard exceptions.

Enhancements:
- Remove an unused PlaudWebhookHandler import from the Plaud webhook server module and apply minor formatting cleanups.