### PR TITLE
🧹 [Code Health] Remove unused imports in analytics.py

### DIFF
--- a/src/chronos/analytics.py
+++ b/src/chronos/analytics.py
@@ -7,16 +7,10 @@ like "What happens on Mondays?" and "What do I think about on Thursdays?"
 import logging
 from typing import List, Dict, Any
 from collections import Counter
-from datetime import datetime
 
 from sqlalchemy.orm import Session
 
-from src.database.chronos_repository import (
-    get_chronos_events_by_day,
-    get_chronos_events_by_date_range,
-)
 from src.chronos.qdrant_client import ChronosQdrantClient
-from src.chronos.embedding_service import ChronosEmbeddingService
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`datetime`, `get_chronos_events_by_day`, `get_chronos_events_by_date_range`, and `ChronosEmbeddingService`) from `src/chronos/analytics.py`.
💡 **Why:** Reduces namespace pollution, clears up linter warnings, and improves maintainability of the codebase.
✅ **Verification:** Validated that unused imports are removed via ruff check and confirmed `pytest` still passes with no functionality regressions.
✨ **Result:** A cleaner and lint-free `analytics.py` script.

---
*PR created automatically by Jules for task [10567172824432966252](https://jules.google.com/task/10567172824432966252) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Simplify the analytics module by removing unused imports for datetime, Chronos repository helpers, and the Chronos embedding service.