### PR TITLE
🧹 Remove unused imports in engine.py

### DIFF
--- a/src/chronos/engine.py
+++ b/src/chronos/engine.py
@@ -17,8 +17,6 @@ from src.config import get_settings
 from src.models.chronos_schemas import (
     ChronosEvent,
     GeminiEventOutput,
-    DayOfWeek,
-    EventCategory,
 )
 
 from src.chronos.genai_helpers import (


### PR DESCRIPTION
🎯 **What:** Removed unused imports `DayOfWeek` and `EventCategory` from `src/chronos/engine.py`.
💡 **Why:** These imports were not used anywhere in the file. Removing them reduces clutter and improves readability.
✅ **Verification:** Ran `black` and `ruff` which indicated code is clean and properly formatted. Ran test suite to ensure no breakage.
✨ **Result:** Cleaned up code health issue without affecting functionality.

---
*PR created automatically by Jules for task [12004312512571038442](https://jules.google.com/task/12004312512571038442) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Clean up src/chronos/engine.py by removing unused DayOfWeek and EventCategory imports.