### PR TITLE
🧹 Remove unused import in src/plaud_auto_sync.py

### DIFF
--- a/src/plaud_auto_sync.py
+++ b/src/plaud_auto_sync.py
@@ -30,7 +30,6 @@ from .plaud_usb_watcher import (
     PlaudUSBWatcher,
     USBPlaudDevice,
     get_usb_watcher,
-    start_watcher,
 )
 from .plaud_webhook import PlaudEvent, PlaudEventType
 from .config import get_settings


### PR DESCRIPTION
🎯 **What:** Removed the unused `start_watcher` import from the `plaud_usb_watcher` import block in `src/plaud_auto_sync.py`.
💡 **Why:** This removes clutter, resolves a linter warning for unused imports, and improves codebase readability without changing any behavior.
✅ **Verification:** Verified by checking that `start_watcher` was not used anywhere in the file and running the full pytest suite.
✨ **Result:** Improved code cleanliness.

---
*PR created automatically by Jules for task [1263525762739111805](https://jules.google.com/task/1263525762739111805) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove an unused start_watcher import from plaud_auto_sync to reduce clutter and improve readability.