### PR TITLE
🧹 Remove unused import in check_metrics.py

### DIFF
--- a/check_metrics.py
+++ b/check_metrics.py
@@ -1,10 +1,9 @@
 from google.cloud import monitoring_v3
 from google.protobuf.timestamp_pb2 import Timestamp
 import time
-import os
 
 client = monitoring_v3.MetricServiceClient()
-project_name = f"projects/composed-facet-360120"
+project_name = "projects/composed-facet-360120"
 
 now = time.time()
 start = Timestamp()


### PR DESCRIPTION
🎯 **What:** Removed unused `import os` in `check_metrics.py`. Also, fixed an f-string issue via `ruff`.
💡 **Why:** Having unused imports clutters the code and hinders maintainability.
✅ **Verification:** Ran `python -m py_compile`, `pytest` and `ruff` / `black` to ensure correct functionality and clean code. All verified perfectly.
✨ **Result:** Improved codebase cleanliness and maintainability without changing any functionality.

---
*PR created automatically by Jules for task [9065830072181255630](https://jules.google.com/task/9065830072181255630) started by @Gunnarguy*

## Summary by Sourcery

Clean up check_metrics module by removing an unused import and simplifying a constant string definition.

Enhancements:
- Remove an unused os import from check_metrics.py to reduce clutter.
- Simplify the project_name definition by using a plain string instead of an f-string.