### PR TITLE
🧹 [Code Health] Remove unused import in trace_service.py

### DIFF
--- a/src/chronos/trace_service.py
+++ b/src/chronos/trace_service.py
@@ -5,8 +5,6 @@ pipeline a single vocabulary for "what ran what" while also bridging every span
 back into the existing X-Ray UI stream.
 """
 
-from __future__ import annotations
-
 import contextvars
 import hashlib
 import os
@@ -264,6 +262,7 @@ def trace_span(
     except Exception as exc:
         elapsed = round(handle.elapsed_ms(), 1)
         err = str(exc)[:500]
+        exc_type = exc.__class__.__name__
 
         def _persist_error(session):
             from src.database.chronos_repository import finish_execution_span
@@ -274,7 +273,7 @@ def trace_span(
                 status="failed",
                 level="error",
                 error_message=err,
-                metadata={"exception_type": exc.__class__.__name__},
+                metadata={"exception_type": exc_type},
             )
 
         _with_session(_persist_error)


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`from __future__ import annotations`) and fixed a closure scope issue with exception variables.
💡 **Why:** `from __future__ import annotations` was unused. While fixing this and triggering `ruff`, a scoping issue was identified where the local exception instance `exc` was being caught in a closure. This was fixed by storing the exception's name in `exc_type` before passing it to the closure function (`_persist_error`).
✅ **Verification:** Re-ran `black` and `ruff` which both passed correctly. Re-ran the full test suite (`pytest tests/`), and verified 353 passing tests. 
✨ **Result:** Cleaned up unused import and fixed a Python scoping issue without changing program behavior.

---
*PR created automatically by Jules for task [12059951027097008620](https://jules.google.com/task/12059951027097008620) started by @Gunnarguy*

## Summary by Sourcery

Bug Fixes:
- Preserve the correct exception type in persisted error metadata by storing the exception class name before invoking the session-bound closure.