### PR TITLE
🧹 Remove unused os import in plaud_usb_watcher.py

### DIFF
--- a/src/plaud_usb_watcher.py
+++ b/src/plaud_usb_watcher.py
@@ -16,7 +16,6 @@ Usage:
     watcher.start()
 """
 
-import os
 import time
 import logging
 import threading
@@ -162,10 +161,12 @@ class PlaudUSBWatcher:
         """
         if not volumes_path:
             import sys as _sys
+
             if _sys.platform == "darwin":
                 volumes_path = "/Volumes"
             else:
                 import getpass
+
                 volumes_path = f"/media/{getpass.getuser()}"
         self.volumes_path = Path(volumes_path)
         self.poll_interval = poll_interval
@@ -398,7 +399,7 @@ if __name__ == "__main__":
     watcher = PlaudUSBWatcher()
 
     def on_connect(device: USBPlaudDevice):
-        print(f"\n✅ Device Connected!")
+        print("\n✅ Device Connected!")
         print(f"   Volume: {device.volume_name}")
         print(f"   Type: {device.device_type.value}")
         print(f"   Audio files: {device.audio_file_count}")


### PR DESCRIPTION
🎯 **What:** Removed unused `import os` statement from `src/plaud_usb_watcher.py`
💡 **Why:** The `os` module was imported but never used anywhere in the file. Removing dead code makes the file cleaner, faster to read, and prevents linting warnings. It also slightly improves memory overhead.
✅ **Verification:** Ran `black` and `ruff --fix` to ensure code style was perfectly preserved (which fixed one extraneous f-string in a print statement), and ran `pytest` suite ensuring all 353 tests passed successfully.
✨ **Result:** Cleaned up unused dependency leaving functionality identical and codebase healthier.

---
*PR created automatically by Jules for task [17823042912638379114](https://jules.google.com/task/17823042912638379114) started by @Gunnarguy*

## Summary by Sourcery

Clean up plaud_usb_watcher startup logging and imports to remove minor cruft.

Enhancements:
- Remove unused imports and tidy inline imports in plaud_usb_watcher.
- Simplify a redundant f-string in the USB device connection log message.