### PR TITLE
🧪 [Add test for get_webhook_server singleton]

### DIFF
--- a/tests/test_plaud_webhook_server.py
+++ b/tests/test_plaud_webhook_server.py
@@ -1,0 +1,28 @@
+
+import src.plaud_webhook_server as plaud_webhook_server_module
+from src.plaud_webhook_server import get_webhook_server, PlaudWebhookServer
+
+
+def test_get_webhook_server_singleton():
+    """Test that get_webhook_server implements the singleton pattern correctly."""
+    # Ensure a clean state before testing
+    original_server = plaud_webhook_server_module._webhook_server
+    plaud_webhook_server_module._webhook_server = None
+
+    try:
+        # First call should create a new instance
+        server1 = get_webhook_server()
+        assert isinstance(server1, PlaudWebhookServer)
+
+        # Second call should return the exact same instance
+        server2 = get_webhook_server()
+        assert server1 is server2
+
+        # Resetting the global should cause a new instance to be created
+        plaud_webhook_server_module._webhook_server = None
+        server3 = get_webhook_server()
+        assert isinstance(server3, PlaudWebhookServer)
+        assert server3 is not server1
+    finally:
+        # Restore the original state to not affect other tests
+        plaud_webhook_server_module._webhook_server = original_server


### PR DESCRIPTION
🎯 **What:** Adding a test file tests/test_plaud_webhook_server.py to ensure the get_webhook_server() function in src/plaud_webhook_server.py behaves as a singleton.
📊 **Coverage:** Specifically tested that get_webhook_server() returns the exact same instance across multiple calls. Also mocked internal state clearing (plaud_webhook_server_module._webhook_server = None) to verify the function initializes correctly when None.
✨ **Result:** Test suite coverage has been improved with tests passing properly. The singleton behavior is successfully guaranteed by the test.

---
*PR created automatically by Jules for task [16140540427258411755](https://jules.google.com/task/16140540427258411755) started by @Gunnarguy*

## Summary by Sourcery

Tests:
- Add tests for get_webhook_server to confirm it returns the same PlaudWebhookServer instance across calls and creates a new instance when the internal singleton state is cleared.