### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,9 @@
 import sys
-if sys.platform in ('linux', 'darwin'):
+
+if sys.platform in ("linux", "darwin"):
     try:
         import uvloop
+
         uvloop.install()
     except ImportError:
         pass
@@ -70,8 +72,16 @@ app.add_middleware(
     ],
     allow_origin_regex=r"^https?://(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3})(:\d+)?$",
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+    allow_headers=[
+        "Content-Type",
+        "Authorization",
+        "Accept",
+        "Origin",
+        "X-Requested-With",
+        "ngrok-skip-browser-warning",
+        "X-Request-ID",
+    ],
 )
 
 # ── Register routers ────────────────────────────────────────


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The CORS middleware in api/main.py had an overly permissive configuration where both allow_methods and allow_headers were set to the wildcard ['*'], while allow_credentials was enabled (True).

⚠️ **Risk:** The potential impact if left unfixed
An overly permissive CORS policy, particularly when credentials are allowed, exposes the application to Cross-Site Request Forgery (CSRF) and unwanted cross-origin access. Attackers could potentially exploit this to craft malicious web pages that execute unauthorized requests in the context of an authenticated user's session, leading to unauthorized data access or modification.

🛡️ **Solution:** How the fix addresses the vulnerability
The wildcard ['*'] for allow_methods has been replaced with an explicit list of necessary HTTP methods (['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']). Similarly, allow_headers has been restricted to an explicit, safe list of headers necessary for the iOS client and standard API operations (['Content-Type', 'Authorization', 'Accept', 'Origin', 'X-Requested-With', 'ngrok-skip-browser-warning', 'X-Request-ID']). This restricts cross-origin interactions to specifically approved methods and headers.

---
*PR created automatically by Jules for task [9686319849309848588](https://jules.google.com/task/9686319849309848588) started by @Gunnarguy*

## Summary by Sourcery

Tighten the API CORS configuration to remove overly permissive wildcard settings while keeping existing local-origin support intact.

Bug Fixes:
- Replace wildcard CORS methods and headers with an explicit allowlist of required HTTP methods and headers to mitigate security risks from overly permissive cross-origin access.

Enhancements:
- Normalize platform check formatting and maintain uvloop initialization without functional changes.