### PR TITLE
🧹 Remove unused Path import in plaud_auto_sync.py

### DIFF
--- a/src/plaud_auto_sync.py
+++ b/src/plaud_auto_sync.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Optional, Dict, Any, List, Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -30,7 +29,6 @@ from .plaud_usb_watcher import (
     PlaudUSBWatcher,
     USBPlaudDevice,
     get_usb_watcher,
-    start_watcher,
 )
 from .plaud_webhook import PlaudEvent, PlaudEventType
 from .config import get_settings


### PR DESCRIPTION
🎯 What: Removed the unused `from pathlib import Path` and `start_watcher` import statements in `src/plaud_auto_sync.py`.
💡 Why: Improves code cleanliness, maintainability, and removes potential confusion by ensuring all imports are actively used.
✅ Verification: Ran `ruff check` and `python -m pytest tests/` which executed successfully.
✨ Result: `src/plaud_auto_sync.py` is cleaner and free of unused imports.

---
*PR created automatically by Jules for task [13408202787430099384](https://jules.google.com/task/13408202787430099384) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove unused imports from plaud_auto_sync to improve code cleanliness.