### PR TITLE
🧹 Remove unused imports in src/chronos/engine.py

### DIFF
--- a/src/chronos/engine.py
+++ b/src/chronos/engine.py
@@ -17,8 +17,6 @@ from src.config import get_settings
 from src.models.chronos_schemas import (
     ChronosEvent,
     GeminiEventOutput,
-    DayOfWeek,
-    EventCategory,
 )
 
 from src.chronos.genai_helpers import (


### PR DESCRIPTION
🎯 **What:** Removed unused imports `DayOfWeek` and `EventCategory` from `src/chronos/engine.py`.
💡 **Why:** To improve code maintainability and readability by keeping imports clean.
✅ **Verification:** Verified by checking that these symbols were indeed unused in the file, and running the full pytest suite.
✨ **Result:** Cleaned up code without affecting behavior.

---
*PR created automatically by Jules for task [15268271389131816585](https://jules.google.com/task/15268271389131816585) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove unused DayOfWeek and EventCategory imports from src/chronos/engine.py.