### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,9 @@
 import sys
-if sys.platform in ('linux', 'darwin'):
+
+if sys.platform in ("linux", "darwin"):
     try:
         import uvloop
+
         uvloop.install()
     except ImportError:
         pass
@@ -25,7 +27,6 @@ from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.middleware.gzip import GZipMiddleware  # noqa: E402
 
 from src.database import init_db  # noqa: E402
-
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +71,8 @@ app.add_middleware(
     ],
     allow_origin_regex=r"^https?://(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3})(:\d+)?$",
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # ── Register routers ────────────────────────────────────────


### PR DESCRIPTION
🎯 **What:** The CORS configuration in `api/main.py` was using wildcards for allowed methods and headers (`allow_methods=["*"]`, `allow_headers=["*"]`) while also setting `allow_credentials=True`.
⚠️ **Risk:** This combination is an overly permissive configuration that can expose the application to Cross-Origin Resource Sharing (CORS) based attacks, specifically potentially exposing authenticated user sessions and data to unauthorized origins when credentials (like cookies or tokens) are involved.
🛡️ **Solution:** The fix replaces the wildcards with explicit lists of allowed methods (`GET`, `POST`, `PUT`, `OPTIONS`) and headers (`Authorization`, `Content-Type`). This adheres to the principle of least privilege, allowing only what's necessary for the application to function correctly and preventing potential abuse.

---
*PR created automatically by Jules for task [2972876634144295645](https://jules.google.com/task/2972876634144295645) started by @Gunnarguy*