### PR TITLE
🧹 [Code Health] Remove unused imports in src/chronos/analytics.py

### DIFF
--- a/src/chronos/analytics.py
+++ b/src/chronos/analytics.py
@@ -7,16 +7,10 @@ like "What happens on Mondays?" and "What do I think about on Thursdays?"
 import logging
 from typing import List, Dict, Any
 from collections import Counter
-from datetime import datetime
 
 from sqlalchemy.orm import Session
 
-from src.database.chronos_repository import (
-    get_chronos_events_by_day,
-    get_chronos_events_by_date_range,
-)
 from src.chronos.qdrant_client import ChronosQdrantClient
-from src.chronos.embedding_service import ChronosEmbeddingService
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
🎯 **What:** Removed several unused imports (`datetime`, `get_chronos_events_by_day`, `get_chronos_events_by_date_range`, and `ChronosEmbeddingService`) from `src/chronos/analytics.py`.
💡 **Why:** Having unused imports clutters the code and makes it harder to identify the dependencies. Removing them improves maintainability, readability, and linting compliance.
✅ **Verification:** Verified with `ruff check` that the file no longer reports unused imports, and ran the full `pytest` suite ensuring all tests still pass, confirming the changes are safe.
✨ **Result:** A cleaner import block without breaking functionality.

---
*PR created automatically by Jules for task [6675204603229688691](https://jules.google.com/task/6675204603229688691) started by @Gunnarguy*