### PR TITLE
🧪 Add edge case test for empty lists in match_notion_to_chronos

### DIFF
--- a/tests/test_notion_bridge.py
+++ b/tests/test_notion_bridge.py
@@ -159,3 +159,14 @@ def test_get_import_progress_pauses_legacy_running_file_without_pid(monkeypatch)
         == "Import progress came from an older worker and is no longer active"
     )
     assert saved["status"] == "paused"
+
+def test_match_notion_to_chronos_empty_lists():
+    from src.chronos.notion_bridge import match_notion_to_chronos
+    from unittest.mock import Mock
+
+    session = Mock()
+    session.query().all.return_value = []
+
+    matches = match_notion_to_chronos([], session)
+
+    assert matches == {}


### PR DESCRIPTION
🎯 **What:** Added a test to verify that passing an empty list of Notion pages to `match_notion_to_chronos` safely returns an empty result set.
📊 **Coverage:** Covers the edge case where no Notion recordings are passed for processing, ensuring no index errors are thrown.
✨ **Result:** Improves test coverage and confirms the reliability of the matching logic against empty input.

---
*PR created automatically by Jules for task [14614938157093109453](https://jules.google.com/task/14614938157093109453) started by @Gunnarguy*

## Summary by Sourcery

Tests:
- Add a test verifying match_notion_to_chronos returns an empty result set when given an empty list and an empty query result.