### PR TITLE
🔒 Fix fail open JWT authentication default

### DIFF
--- a/api/auth/jwt.py
+++ b/api/auth/jwt.py
@@ -28,20 +28,16 @@ def require_auth(
 ) -> str:
     """Validate the Bearer token. Returns the token string.
 
-    If CHRONOS_API_KEY is unset (dev mode), all requests are allowed
-    unless CHRONOS_REQUIRE_AUTH=1 is configured.
+    Requests require a valid Bearer token matching CHRONOS_API_KEY.
     """
     api_key = _get_api_key()
-    require_auth_env = os.getenv("CHRONOS_REQUIRE_AUTH", "") == "1"
 
-    # Dev mode: no key configured → skip auth (unless forced by CHRONOS_REQUIRE_AUTH=1)
+    # Fail closed: if no key is configured, reject all requests.
     if not api_key:
-        if require_auth_env:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Unauthorized: Authentication is required, but CHRONOS_API_KEY is not configured",
-            )
-        return "dev"
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized: Server is improperly configured (missing CHRONOS_API_KEY)",
+        )
 
     if credentials is None:
         raise HTTPException(

--- a/api/routes/xray.py
+++ b/api/routes/xray.py
@@ -262,7 +262,7 @@ def _ws_event_matches(
 async def _websocket_auth_ok(websocket: WebSocket) -> bool:
     api_key = os.getenv("CHRONOS_API_KEY", "")
     if not api_key:
-        return True
+        return False
 
     token = websocket.query_params.get("token") or ""
     auth = websocket.headers.get("authorization", "")

--- a/submission.txt
+++ b/submission.txt
@@ -1,0 +1,5 @@
+🎯 **What:** The codebase previously contained a "Fail Open" JWT Authentication Default vulnerability. Specifically, if `CHRONOS_API_KEY` was missing from the environment configuration, the `require_auth` function bypassed authentication by default (treating it as an unauthenticated "dev" mode). Furthermore, the `_websocket_auth_ok` check in `xray.py` similarly permitted all websocket connections when `CHRONOS_API_KEY` was missing.
+
+⚠️ **Risk:** If left unfixed, an unconfigured or improperly configured production environment missing `CHRONOS_API_KEY` would silently fall back to "dev mode", thereby exposing sensitive API endpoints and WebSocket channels to the public internet without requiring any authorization credentials.
+
+🛡️ **Solution:** Modified `require_auth` in `api/auth/jwt.py` and `_websocket_auth_ok` in `api/routes/xray.py` to fail closed. Now, if `CHRONOS_API_KEY` is empty or missing, requests will be correctly rejected with a `401 Unauthorized` response (or a closed websocket connection). Tests were additionally updated to reflect this behavior.

--- a/test_script.py
+++ b/test_script.py
@@ -1,0 +1,2 @@
+import requests
+print("Done")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -278,20 +278,22 @@ def mock_svc():
 
 @pytest.fixture()
 def client(mock_svc):
-    """Create TestClient with mocked dependencies and no auth."""
+    """Create TestClient with mocked dependencies and standard auth headers."""
     # Clear the lru_cache before importing the app
     from api.dependencies import get_service
 
     get_service.cache_clear()
 
-    # Patch environment so auth is disabled (dev mode)
-    with patch.dict(os.environ, {"CHRONOS_API_KEY": ""}, clear=False):
+    # Patch environment with a valid API key
+    with patch.dict(os.environ, {"CHRONOS_API_KEY": "test-secret-key"}, clear=False):
         # Override the get_service dependency
         from api.main import app
         from api.dependencies import get_service as gs
 
         app.dependency_overrides[gs] = lambda: mock_svc
-        yield TestClient(app, raise_server_exceptions=False)
+        client = TestClient(app, raise_server_exceptions=False)
+        client.headers.update({"Authorization": "Bearer test-secret-key"})
+        yield client
         app.dependency_overrides.clear()
 
 
@@ -397,9 +399,10 @@ class TestAuthEnforcement:
         assert r.status_code == 200
 
     def test_dev_mode_no_auth_required(self, client):
-        """When CHRONOS_API_KEY is empty, no auth needed."""
-        r = client.get("/api/v1/timeline/days")
-        assert r.status_code == 200
+        """When CHRONOS_API_KEY is empty, request is rejected to fail securely."""
+        with patch.dict("os.environ", {"CHRONOS_API_KEY": ""}, clear=False):
+            r = client.get("/api/v1/timeline/days")
+            assert r.status_code == 401
 
     def test_require_auth_missing_key_public_mode(self, client):
         """When CHRONOS_REQUIRE_AUTH=1 and CHRONOS_API_KEY is empty, request is rejected."""
@@ -836,6 +839,10 @@ class TestSettings:
             chronos_autosync_min_available_mb=500,
             chronos_autosync_max_swap_used_mb=256,
             chronos_autosync_defer_seconds=60,
+            chronos_index_events_per_limit=10,
+            chronos_autosync_index_timeout=3600,
+            chronos_autosync_graph_timeout=3600,
+            chronos_stats_enable_plaud_cloud=True,
             gemini_api_key="test-gemini",
             openai_api_key_configured=False,
             qdrant_api_key=None,


### PR DESCRIPTION
🎯 **What:** The codebase previously contained a "Fail Open" JWT Authentication Default vulnerability. Specifically, if `CHRONOS_API_KEY` was missing from the environment configuration, the `require_auth` function bypassed authentication by default (treating it as an unauthenticated "dev" mode). Furthermore, the `_websocket_auth_ok` check in `xray.py` similarly permitted all websocket connections when `CHRONOS_API_KEY` was missing.

⚠️ **Risk:** If left unfixed, an unconfigured or improperly configured production environment missing `CHRONOS_API_KEY` would silently fall back to "dev mode", thereby exposing sensitive API endpoints and WebSocket channels to the public internet without requiring any authorization credentials.

🛡️ **Solution:** Modified `require_auth` in `api/auth/jwt.py` and `_websocket_auth_ok` in `api/routes/xray.py` to fail closed. Now, if `CHRONOS_API_KEY` is empty or missing, requests will be correctly rejected with a `401 Unauthorized` response (or a closed websocket connection). Tests were additionally updated to reflect this behavior.

---
*PR created automatically by Jules for task [11307878333230718870](https://jules.google.com/task/11307878333230718870) started by @Gunnarguy*

## Summary by Sourcery

Enforce strict JWT and websocket authentication by failing closed when CHRONOS_API_KEY is not configured.

New Features:
- Expose additional autosync and indexing configuration fields in the settings API response.

Bug Fixes:
- Prevent unauthenticated HTTP requests from being accepted when CHRONOS_API_KEY is missing by treating this as a misconfiguration and returning 401.
- Prevent unauthenticated websocket connections from being accepted when CHRONOS_API_KEY is missing by failing the auth check.

Enhancements:
- Update API test client setup to use a valid API key and standard Authorization headers, and adjust tests to cover the new fail-closed behavior for missing CHRONOS_API_KEY.

Chores:
- Add auxiliary test_script.py and submission.txt files to the repository.